### PR TITLE
Fix 53 self-transpile errors (368→315)

### DIFF
--- a/tongues/src/backend/perl.py
+++ b/tongues/src/backend/perl.py
@@ -148,7 +148,10 @@ def _escape_perl_regex(s: str) -> str:
         elif ch == "\r":
             result.append("\\r")
         elif ord(ch) < 32 or ord(ch) > 126:
-            result.append("\\x{" + ("%02x" % ord(ch)) + "}")
+            h = hex(ord(ch))[2:]
+            if len(h) == 1:
+                h = "0" + h
+            result.append("\\x{" + h + "}")
         else:
             result.append(ch)
     return "".join(result)
@@ -170,7 +173,10 @@ def _escape_perl_replacement(s: str) -> str:
         elif ch == "\r":
             result.append("\\r")
         elif ord(ch) < 32 or ord(ch) > 126:
-            result.append("\\x{" + ("%02x" % ord(ch)) + "}")
+            h = hex(ord(ch))[2:]
+            if len(h) == 1:
+                h = "0" + h
+            result.append("\\x{" + h + "}")
         else:
             result.append(ch)
     return "".join(result)
@@ -188,7 +194,10 @@ def _escape_regex_charclass(s: str) -> str:
         elif ch == "\r":
             result.append("\\r")
         elif ord(ch) < 32 or ord(ch) > 126:
-            result.append("\\x{" + ("%02x" % ord(ch)) + "}")
+            h = hex(ord(ch))[2:]
+            if len(h) == 1:
+                h = "0" + h
+            result.append("\\x{" + h + "}")
         else:
             result.append(ch)
     return "".join(result)

--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -233,12 +233,12 @@ def _scan_imports(
                     if isinstance(fld.typ, (TListType, TMapType, TSetType)):
                         needs_field = True
         if isinstance(decl, (TFnDecl, TStructDecl)):
-            result = _scan_decl_builtins(decl)
-            if result[0]:
+            r_sys, r_math, r_os = _scan_decl_builtins(decl)
+            if r_sys:
                 needs_sys = True
-            if result[1]:
+            if r_math:
                 needs_math = True
-            if result[2]:
+            if r_os:
                 needs_os = True
     return needs_sys, needs_dataclass, needs_field, needs_math, needs_os
 

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -907,6 +907,10 @@ def _infer_expr_type(node: ASTNode, env: _Env, ctx: _LowerCtx) -> TypeNode:
                 fn_args = get_nodes(node, "args")
                 if len(fn_args) > 0:
                     at = _infer_expr_type(fn_args[0], env, ctx)
+                    if isinstance(at, MapType):
+                        return SliceType(at.key)
+                    if isinstance(at, SetType):
+                        return SliceType(at.element)
                     return at
                 return SliceType(INT_TYPE)
             if fname == "list":
@@ -938,6 +942,16 @@ def _infer_expr_type(node: ASTNode, env: _Env, ctx: _LowerCtx) -> TypeNode:
                 return PointerType(StructRef(fname))
             rt = _func_return_type(ctx, fname)
             return rt
+        if _is_ast(func, "Subscript"):
+            sub_value = get_node(func, "value")
+            if _is_ast(sub_value, "Name"):
+                sub_name = get_str(sub_value, "id")
+                if sub_name == "set" or sub_name == "frozenset":
+                    return SetType(STR_TYPE)
+                if sub_name == "dict":
+                    return MapType(STR_TYPE, VOID_TYPE)
+                if sub_name == "list":
+                    return SliceType(VOID_TYPE)
         if _is_ast(func, "Attribute"):
             method_name = get_str(func, "attr")
             obj_n = get_node(func, "value")
@@ -1391,6 +1405,10 @@ def _lower_binop(node: ASTNode, env: _Env, ctx: _LowerCtx) -> TExpr:
         if _is_type_dict(left_type, ["string"]) or _is_type_dict(
             right_type, ["string"]
         ):
+            if _is_type_dict(left_type, ["rune"]):
+                left = _make_call(pos, "ToString", [left])
+            if _is_type_dict(right_type, ["rune"]):
+                right = _make_call(pos, "ToString", [right])
             return _make_call(pos, "Concat", [left, right])
         if _is_type_dict(left_type, ["bytes"]) or _is_type_dict(right_type, ["bytes"]):
             return _make_call(pos, "Concat", [left, right])
@@ -2037,6 +2055,13 @@ def _lower_call(node: ASTNode, env: _Env, ctx: _LowerCtx) -> TExpr:
     if _is_ast(func_node, "Name"):
         fname = get_str(func_node, "id")
         return _lower_name_call(fname, args, keywords, node, env, ctx)
+    # Parameterized constructor: set[T](), dict[K,V](), list[T](), frozenset[T]()
+    if _is_ast(func_node, "Subscript"):
+        sub_value = get_node(func_node, "value")
+        if _is_ast(sub_value, "Name"):
+            sub_name = get_str(sub_value, "id")
+            if sub_name in ("set", "dict", "list", "frozenset"):
+                return _lower_name_call(sub_name, args, keywords, node, env, ctx)
     # Method call
     if _is_ast(func_node, "Attribute"):
         return _lower_method_call(func_node, args, keywords, node, env, ctx)
@@ -2202,7 +2227,14 @@ def _lower_name_call(
             )
     if fname == "chr":
         if len(args) > 0 and isinstance(args[0], dict):
-            rune = _make_call(pos, "RuneFromInt", [_lower_expr(args[0], env, ctx)])
+            arg_type = _infer_expr_type(args[0], env, ctx)
+            arg = _lower_expr(args[0], env, ctx)
+            if _is_type_dict(arg_type, ["byte"]):
+                rune = _make_call(
+                    pos, "RuneFromInt", [_make_call(pos, "ByteToInt", [arg])]
+                )
+            else:
+                rune = _make_call(pos, "RuneFromInt", [arg])
             return _make_call(pos, "ToString", [rune])
     if fname == "ord":
         if len(args) > 0 and isinstance(args[0], dict):
@@ -2243,8 +2275,10 @@ def _lower_name_call(
             return _make_call(pos, "ToString", [_lower_expr(args[0], env, ctx)])
     if fname == "sorted":
         if len(args) > 0 and isinstance(args[0], dict):
+            arg_type = _infer_expr_type(args[0], env, ctx)
             arg = _lower_expr(args[0], env, ctx)
-            # Check for reverse=True
+            if isinstance(arg_type, MapType):
+                arg = _make_call(pos, "Keys", [arg])
             is_reversed = _has_keyword_true(keywords, "reverse")
             if is_reversed:
                 return _make_call(pos, "Reversed", [_make_call(pos, "Sorted", [arg])])
@@ -2354,6 +2388,16 @@ def _lower_name_call(
             # set(list_expr) → SetFromList(list_expr)
             if _is_type_dict(arg_type, ["Slice"]):
                 return _make_call(pos, "SetFromList", [_lower_expr(args[0], env, ctx)])
+            # set(tuple_literal) → SetFromList([...]) — wrap tuple as list
+            if _is_ast(args[0], "Tuple") or isinstance(arg_type, TupleType):
+                lowered_arg = _lower_expr(args[0], env, ctx)
+                if isinstance(lowered_arg, TTupleLit):
+                    return _make_call(
+                        pos,
+                        "SetFromList",
+                        [TListLit(pos, lowered_arg.elements, _EMPTY_ANN)],
+                    )
+                return _make_call(pos, "SetFromList", [lowered_arg])
             # set(any_iterable) → SetFromList(expr)
             return _make_call(pos, "SetFromList", [_lower_expr(args[0], env, ctx)])
     if fname == "tuple":
@@ -2391,13 +2435,23 @@ def _lower_name_call(
         if len(args) == 0:
             return _make_call(pos, "Map", [])
         if len(args) == 1 and isinstance(args[0], dict):
+            arg_type = _infer_expr_type(args[0], env, ctx)
+            if isinstance(arg_type, MapType):
+                items = _make_call(pos, "Items", [_lower_expr(args[0], env, ctx)])
+                return _make_call(pos, "MapFromPairs", [items])
             return _make_call(pos, "MapFromPairs", [_lower_expr(args[0], env, ctx)])
     if fname == "hex":
         if len(args) > 0 and isinstance(args[0], dict):
+            arg_type = _infer_expr_type(args[0], env, ctx)
+            arg = _lower_expr(args[0], env, ctx)
+            if _is_type_dict(arg_type, ["byte"]):
+                int_arg = _make_call(pos, "ByteToInt", [arg])
+            else:
+                int_arg = arg
             return _make_call(
                 pos,
                 "FormatInt",
-                [_lower_expr(args[0], env, ctx), TIntLit(pos, 16, "16", _EMPTY_ANN)],
+                [int_arg, TIntLit(pos, 16, "16", _EMPTY_ANN)],
             )
     if fname == "divmod":
         if len(args) >= 2 and isinstance(args[0], dict) and isinstance(args[1], dict):
@@ -2793,6 +2847,14 @@ def _lower_list_method(
         lowered.append(_lower_expr(a, env, ctx))
         i += 1
     if method == "append":
+        if len(lowered) > 0 and len(args) > 0:
+            obj_type = _infer_expr_type(obj_node, env, ctx)
+            if isinstance(obj_type, SliceType) and _is_type_dict(
+                obj_type.element, ["string"]
+            ):
+                arg_type = _infer_expr_type(args[0], env, ctx)
+                if _is_type_dict(arg_type, ["rune"]):
+                    lowered[0] = _make_call(pos, "ToString", [lowered[0]])
         return _make_call(pos, "Append", [obj] + lowered)
     if method == "insert":
         return _make_call(pos, "Insert", [obj] + lowered)
@@ -3767,6 +3829,10 @@ def _lower_aug_assign(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
         if target_type is not None and _is_type_dict(target_type, ["string", "bytes"]):
             target = _lower_expr(target_node, env, ctx)
             value = _lower_expr(value_node, env, ctx)
+            if _is_type_dict(target_type, ["string"]):
+                vtype = _infer_expr_type(value_node, env, ctx)
+                if _is_type_dict(vtype, ["rune"]):
+                    value = _make_call(pos, "ToString", [value])
             return [
                 TAssignStmt(
                     pos, target, _make_call(pos, "Concat", [target, value]), _EMPTY_ANN
@@ -4442,6 +4508,10 @@ def _lower_for(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
             obj_node = get_node(func, "value")
             iter_expr = _lower_expr(obj_node, env, ctx)
             binding, b_ann = _extract_binding(target_node)
+            obj_type = _infer_expr_type(obj_node, env, ctx)
+            if isinstance(obj_type, MapType) and len(binding) >= 2:
+                env.var_types[binding[0]] = obj_type.key
+                env.var_types[binding[1]] = obj_type.value
             body_stmts = _lower_stmts(body, env, ctx)
             pre_stmts.append(TForStmt(pos, binding, iter_expr, body_stmts, b_ann))
             return pre_stmts
@@ -4464,6 +4534,20 @@ def _lower_for(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
     # Regular iteration: for x in xs
     binding, b_ann = _extract_binding(target_node)
     iter_expr = _lower_expr(iter_node, env, ctx)
+    if len(binding) == 1:
+        elem_type: TypeNode = VOID_TYPE
+        if _is_type_dict(iter_type, ["string"]):
+            elem_type = PrimitiveType("rune")
+        elif _is_type_dict(iter_type, ["bytes"]):
+            elem_type = PrimitiveType("byte")
+        elif isinstance(iter_type, SliceType):
+            elem_type = iter_type.element
+        elif isinstance(iter_type, SetType):
+            elem_type = iter_type.element
+        elif isinstance(iter_type, MapType):
+            elem_type = iter_type.key
+        if elem_type != VOID_TYPE:
+            env.var_types[binding[0]] = elem_type
     body_stmts = _lower_stmts(body, env, ctx)
     pre_stmts.append(TForStmt(pos, binding, iter_expr, body_stmts, b_ann))
     return pre_stmts
@@ -4504,6 +4588,8 @@ def _lower_for_range(
     pos = _node_pos(target_node)
     args = get_nodes(iter_node, "args")
     binding, b_ann = _extract_binding(target_node)
+    if len(binding) == 1:
+        env.var_types[binding[0]] = INT_TYPE
     range_args: list[TExpr] = []
     i = 0
     while i < len(args):
@@ -4555,6 +4641,21 @@ def _lower_for_enumerate(
     # For enumerate over strings, change last binding to "ch"
     if _is_type_dict(inner_type, ["string"]) and len(binding) == 2:
         binding = [binding[0], "ch"]
+    # Register loop variable types
+    if len(binding) >= 1:
+        env.var_types[binding[0]] = INT_TYPE
+    if len(binding) >= 2:
+        elem_type: TypeNode = VOID_TYPE
+        if _is_type_dict(inner_type, ["string"]):
+            elem_type = PrimitiveType("rune")
+        elif _is_type_dict(inner_type, ["bytes"]):
+            elem_type = PrimitiveType("byte")
+        elif isinstance(inner_type, SliceType):
+            elem_type = inner_type.element
+        elif isinstance(inner_type, MapType):
+            elem_type = inner_type.key
+        if elem_type != VOID_TYPE:
+            env.var_types[binding[1]] = elem_type
     body_stmts = _lower_stmts(body, env, ctx)
     return [TForStmt(pos, binding, iter_expr, body_stmts, b_ann)]
 

--- a/tongues/src/frontend/parse.py
+++ b/tongues/src/frontend/parse.py
@@ -3855,7 +3855,9 @@ def process_escapes(s: str, is_bytes: bool, lineno: int = 1, col: int = 0) -> st
             elif next_c == "N" and not is_bytes:
                 if i + 2 >= len(s) or s[i + 2] != "{":
                     raise ParseError("invalid \\N escape", lineno, col)
-                close_brace = s.find("}", i + 3)
+                rest = s[i + 3 :]
+                cb = rest.find("}")
+                close_brace = cb + i + 3 if cb != -1 else -1
                 if close_brace == -1:
                     raise ParseError("invalid \\N escape", lineno, col)
                 name = s[i + 3 : close_brace]
@@ -3907,7 +3909,9 @@ def _fstring_find_expr_end(
             if i + 2 < length and content[i + 1] == quote and content[i + 2] == quote:
                 triple = True
             if triple:
-                end_q = content.find(quote + quote + quote, i + 3)
+                rest_q = content[i + 3 :]
+                eq = rest_q.find(quote + quote + quote)
+                end_q = eq + i + 3 if eq != -1 else -1
                 if end_q == -1:
                     raise ParseError(
                         "unterminated string in f-string expression", lineno, col

--- a/tongues/src/middleend/callgraph.py
+++ b/tongues/src/middleend/callgraph.py
@@ -444,7 +444,7 @@ def _detect_recursion(
                 is_recursive = True
 
         if is_recursive:
-            group_id = f"scc:{scc_counter}"
+            group_id = "scc:" + str(scc_counter)
             scc_counter += 1
         else:
             group_id = ""

--- a/tongues/src/taytsh/ast.py
+++ b/tongues/src/taytsh/ast.py
@@ -616,7 +616,11 @@ class TFnLit(TExpr):
 
 
 def _sa_strip(ann: Ann, pfx: str, plen: int) -> Ann:
-    return {k[plen:]: v for k, v in ann.items() if k.startswith(pfx)}
+    result: Ann = {}
+    for k, v in ann.items():
+        if k.startswith(pfx):
+            result[k[plen:]] = v
+    return result
 
 
 def _sa_collect_lets(
@@ -918,9 +922,10 @@ def _sa_serialize_fn(fn: TFnDecl, pfx: str, plen: int) -> dict[str, JsonValue]:
         for vk, vv in vars_dict.items():
             vd[vk] = _wrap_ann(vv)
         d["vars"] = JDict(vd)
-        escapes: dict[str, JsonValue] = {
-            n: JBool(True) for n, a in vars_dict.items() if a.get("escapes")
-        }
+        escapes: dict[str, JsonValue] = {}
+        for n, a in vars_dict.items():
+            if a.get("escapes") is not None:
+                escapes[n] = JBool(True)
         if escapes:
             d["escapes"] = JDict(escapes)
     return d

--- a/tongues/src/taytsh/emit.py
+++ b/tongues/src/taytsh/emit.py
@@ -96,25 +96,25 @@ class _Emitter:
     _PREC_PRIMARY: int = 13
 
     _BIN_PREC: dict[str, int] = {
-        "||": _PREC_OR,
-        "&&": _PREC_AND,
-        "==": _PREC_COMPARE,
-        "!=": _PREC_COMPARE,
-        "<": _PREC_COMPARE,
-        "<=": _PREC_COMPARE,
-        ">": _PREC_COMPARE,
-        ">=": _PREC_COMPARE,
-        "|": _PREC_BITOR,
-        "^": _PREC_BITXOR,
-        "&": _PREC_BITAND,
-        "<<": _PREC_SHIFT,
-        ">>": _PREC_SHIFT,
-        ">>>": _PREC_SHIFT,
-        "+": _PREC_SUM,
-        "-": _PREC_SUM,
-        "*": _PREC_PRODUCT,
-        "/": _PREC_PRODUCT,
-        "%": _PREC_PRODUCT,
+        "||": 2,
+        "&&": 3,
+        "==": 4,
+        "!=": 4,
+        "<": 4,
+        "<=": 4,
+        ">": 4,
+        ">=": 4,
+        "|": 5,
+        "^": 6,
+        "&": 7,
+        "<<": 8,
+        ">>": 8,
+        ">>>": 8,
+        "+": 9,
+        "-": 9,
+        "*": 10,
+        "/": 10,
+        "%": 10,
     }
 
     def __init__(self) -> None:
@@ -544,7 +544,7 @@ class _Emitter:
             return f"{obj}.{expr.field}"
         if isinstance(expr, TTupleAccess):
             obj2 = self._render_expr(expr.obj, self._PREC_POSTFIX, "left")
-            return f"{obj2}.{expr.index}"
+            return obj2 + "." + str(expr.index)
         if isinstance(expr, TIndex):
             obj3 = self._render_expr(expr.obj, self._PREC_POSTFIX, "left")
             idx = self._render_expr(expr.index, self._PREC_TERNARY)

--- a/tongues/src/tongues.py
+++ b/tongues/src/tongues.py
@@ -1631,6 +1631,7 @@ def run_pipeline(
         strict_tostring = True
     if stop_at == "subset" and should_skip_file(source):
         return (0, "")
+    ast_dict: dict[str, JsonValue] = {}
     try:
         ast_dict = parse(source)
     except ParseError as e:
@@ -1660,7 +1661,7 @@ def parse_args() -> tuple[str, str | None, bool, bool, bool, str | None, str | N
     while i < len(args):
         arg = args[i]
         if arg == "--help" or arg == "-h":
-            print(USAGE, end="")
+            sys.stdout.write(USAGE)
             sys.exit(0)
         elif arg == "--target":
             if i + 1 >= len(args):


### PR DESCRIPTION
## Summary

- Register loop variable types in `env.var_types` across all for-loop paths (regular, enumerate, dict.items, range), fixing cascading type inference failures
- Add byte→int coercion for `chr()`/`hex()`, rune→string coercion for `Concat`/`append`, and proper lowering for `sorted(dict)`, `set(tuple)`, `dict(map)`, and parameterized constructors like `set[T]()`
- Source fixes: rewrite dict comprehensions, `%02x` formatting, 3-arg `str.find`, f-string int interpolation, class constant references in dict literals, and variable scoping issues