### PR TITLE
Reduce self-transpile errors from 122 to 96 via source rewrites

### DIFF
--- a/tongues/src/backend/perl.py
+++ b/tongues/src/backend/perl.py
@@ -1802,10 +1802,10 @@ class _PerlEmitter:
                 + "]"
             )
         if name == "Sorted":
-            inner = args[0].value
-            if self.strict_math and self._is_float_list(inner):
+            sorted_arg = args[0].value
+            if self.strict_math and self._is_float_list(sorted_arg):
                 return "strict_sorted_f64(" + self._a(args, 0) + ")"
-            typ = self._expr_type(inner)
+            typ = self._expr_type(sorted_arg)
             if isinstance(typ, TListType) and _is_string_type(typ.element):
                 return "[sort @{" + self._a(args, 0) + "}]"
             return "[sort { $a <=> $b } @{" + self._a(args, 0) + "}]"

--- a/tongues/src/backend/ruby.py
+++ b/tongues/src/backend/ruby.py
@@ -1093,8 +1093,7 @@ class _RubyEmitter:
             for b in binding:
                 binder_parts.append(_restore_name(b, ann))
             binders = ", ".join(binder_parts)
-            r = stmt.iterable
-            iterable = self._ruby_range(r)
+            iterable = self._ruby_range(stmt.iterable)
             self._line(iterable + ".each do |" + binders + "|")
         elif len(binding) == 1:
             iter_str = self._expr(stmt.iterable)
@@ -1981,8 +1980,8 @@ class _RubyEmitter:
             _farg_parts: list[str] = []
             for a in args:
                 _farg_parts.append(self._expr(a.value))
-            arg_strs = ", ".join(_farg_parts)
-            return "format_(" + arg_strs + ")"
+            joined_args = ", ".join(_farg_parts)
+            return "format_(" + joined_args + ")"
         template = template_expr.value
         fmt_args = args[1:]
         prov = call.annotations.get("provenance", "")
@@ -1991,7 +1990,9 @@ class _RubyEmitter:
             rest = template
             idx = 0
             while "{}" in rest and idx < len(fmt_args):
-                before, rest = rest.split("{}", 1)
+                split_pos = rest.index("{}")
+                before = rest[:split_pos]
+                rest = rest[split_pos + 2 :]
                 parts.append(_escape_ruby_string(before))
                 parts.append("#{" + self._expr(fmt_args[idx].value) + "}")
                 idx += 1

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -9,6 +9,7 @@ Written in the Tongues subset (no generators, closures, lambdas, getattr).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 
 from ..taytsh.ast import (
     Ann,
@@ -4164,8 +4165,9 @@ def _lower_if(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
     # Check for isinstance chain → match statement
     isinstance_result = _extract_isinstance_chain(node)
     if isinstance_result is not None:
-        chain, else_body_nodes = isinstance_result
-        return _lower_isinstance_chain(pos, chain, else_body_nodes, env, ctx)
+        return _lower_isinstance_chain(
+            pos, isinstance_result.cases, isinstance_result.else_body, env, ctx
+        )
     # Split compound "not isinstance(x, T) or ..." guard into sequential ifs
     if _is_ast(test, "BoolOp") and len(orelse) == 0 and _is_guard_body(body):
         op = get_node(test, "op")
@@ -4242,10 +4244,28 @@ def _lower_if(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
     return pre_temps + pre_stmts
 
 
-def _unwrap_isinstance_and(
-    test: ASTNode,
-) -> tuple[ASTNode, list[ASTNode]] | None:
-    """If test is isinstance(x,T) AND ..., return (isinstance_node, rest). Else None."""
+@dataclass
+class _UnwrappedIsinstance:
+    isinstance_node: ASTNode
+    rest: list[ASTNode]
+
+
+@dataclass
+class _IsinstanceCase:
+    var_name: str
+    type_name: str
+    body: list[ASTNode]
+    extra_conds: list[ASTNode] | None
+
+
+@dataclass
+class _IsinstanceChainResult:
+    cases: list[_IsinstanceCase]
+    else_body: list[ASTNode] | None
+
+
+def _unwrap_isinstance_and(test: ASTNode) -> _UnwrappedIsinstance | None:
+    """If test is isinstance(x,T) AND ..., return the isinstance node and rest. Else None."""
     if not _is_ast(test, "BoolOp"):
         return None
     op = get_node(test, "op")
@@ -4256,28 +4276,21 @@ def _unwrap_isinstance_and(
         return None
     if not _is_isinstance_call(values[0]):
         return None
-    return (values[0], values[1:])
+    return _UnwrappedIsinstance(isinstance_node=values[0], rest=values[1:])
 
 
-def _extract_isinstance_chain(
-    node: ASTNode,
-) -> (
-    tuple[
-        list[tuple[str, str, list[ASTNode], list[ASTNode] | None]], list[ASTNode] | None
-    ]
-    | None
-):
-    """Extract isinstance chain from if/elif. Returns (cases, else_body) or None."""
+def _extract_isinstance_chain(node: ASTNode) -> _IsinstanceChainResult | None:
+    """Extract isinstance chain from if/elif. Returns cases + else_body or None."""
     test = get_node(node, "test")
     extra_conds: list[ASTNode] | None = None
     if _is_isinstance_call(test):
         isinstance_node = test
     else:
-        unwrapped_pair = _unwrap_isinstance_and(test)
-        if unwrapped_pair is None:
+        unwrapped = _unwrap_isinstance_and(test)
+        if unwrapped is None:
             return None
-        isinstance_node = unwrapped_pair[0]
-        extra_conds = unwrapped_pair[1]
+        isinstance_node = unwrapped.isinstance_node
+        extra_conds = unwrapped.rest
     var_name = _isinstance_var(isinstance_node)
     if var_name == "":
         return None
@@ -4285,10 +4298,17 @@ def _extract_isinstance_chain(
     if len(type_names) == 0:
         return None
     body = get_nodes(node, "body")
-    result: list[tuple[str, str, list[ASTNode], list[ASTNode] | None]] = []
+    result: list[_IsinstanceCase] = []
     i = 0
     while i < len(type_names):
-        result.append((var_name, type_names[i], body, extra_conds))
+        result.append(
+            _IsinstanceCase(
+                var_name=var_name,
+                type_name=type_names[i],
+                body=body,
+                extra_conds=extra_conds,
+            )
+        )
         i += 1
     orelse = get_nodes(node, "orelse")
     # Check if elif is also isinstance on same var
@@ -4301,22 +4321,20 @@ def _extract_isinstance_chain(
         else:
             unwrapped2 = _unwrap_isinstance_and(next_test)
             if unwrapped2 is not None:
-                unwrapped2_node, unwrapped2_rest = unwrapped2
-                next_isinstance = unwrapped2_node
+                next_isinstance = unwrapped2.isinstance_node
         if next_isinstance is not None and _isinstance_var(next_isinstance) == var_name:
             rest = _extract_isinstance_chain(next_node)
             if rest is not None:
-                rest_cases, rest_else = rest
-                i = 0
-                while i < len(rest_cases):
-                    result.append(rest_cases[i])
-                    i += 1
-                return (result, rest_else)
+                ri = 0
+                while ri < len(rest.cases):
+                    result.append(rest.cases[ri])
+                    ri += 1
+                return _IsinstanceChainResult(cases=result, else_body=rest.else_body)
     # Trailing else (non-isinstance orelse)
     else_body: list[ASTNode] | None = None
     if len(orelse) > 0:
         else_body = orelse
-    return (result, else_body)
+    return _IsinstanceChainResult(cases=result, else_body=else_body)
 
 
 def _is_isinstance_call(node: ASTNode) -> bool:
@@ -4392,7 +4410,7 @@ def _isinstance_types(node: ASTNode) -> list[str]:
 
 def _lower_isinstance_chain(
     pos: Pos,
-    chain: list[tuple[str, str, list[ASTNode], list[ASTNode] | None]],
+    chain: list[_IsinstanceCase],
     else_body_nodes: list[ASTNode] | None,
     env: _Env,
     ctx: _LowerCtx,
@@ -4405,12 +4423,12 @@ def _lower_isinstance_chain(
     all_body_nodes: list[ASTNode] = []
     i = 0
     while i < len(chain):
-        _, _, body_stmts, extra_conds = chain[i]
-        if extra_conds is not None:
+        c = chain[i]
+        if c.extra_conds is not None:
             has_extra = True
         j = 0
-        while j < len(body_stmts):
-            all_body_nodes.append(body_stmts[j])
+        while j < len(c.body):
+            all_body_nodes.append(c.body[j])
             j += 1
         i += 1
     if else_body_nodes is not None:
@@ -4421,13 +4439,16 @@ def _lower_isinstance_chain(
     hoist_names = _scan_hoist_names(all_body_nodes, env)
     pre_stmts: list[TStmt] = []
     _emit_hoisted_placeholders(pos, hoist_names, env, pre_stmts)
-    var_name = chain[0][0]
+    var_name = chain[0].var_name
     sv = _safe_name(var_name)
     expr = TVar(pos, sv, _name_ann(sv, var_name))
     cases: list[TMatchCase] = []
     i = 0
     while i < len(chain):
-        _, type_name, body_stmts, extra_conds = chain[i]
+        c = chain[i]
+        type_name = c.type_name
+        body_stmts = c.body
+        extra_conds = c.extra_conds
         binding_name = type_name[0].lower() + type_name[1:] if type_name else type_name
         if binding_name in env.declared:
             suffix = 2

--- a/tongues/src/taytsh/ast.py
+++ b/tongues/src/taytsh/ast.py
@@ -923,8 +923,8 @@ def _sa_serialize_fn(fn: TFnDecl, pfx: str, plen: int) -> dict[str, JsonValue]:
             vd[vk] = _wrap_ann(vv)
         d["vars"] = JDict(vd)
         escapes: dict[str, JsonValue] = {}
-        for n, a in vars_dict.items():
-            if a.get("escapes") is not None:
+        for n, va in vars_dict.items():
+            if va.get("escapes") is not None:
                 escapes[n] = JBool(True)
         if escapes:
             d["escapes"] = JDict(escapes)

--- a/tongues/src/taytsh/check.py
+++ b/tongues/src/taytsh/check.py
@@ -3719,10 +3719,11 @@ class Checker:
                         return t1u
                     if isinstance(t2u, ListT):
                         return t2u
-                    return ListT(
-                        kind="list",
-                        element=t1u.elements[0] if t1u.elements else ERROR_T,
-                    )
+                    if isinstance(t1u, TupleT):
+                        return ListT(
+                            kind="list",
+                            element=t1u.elements[0] if t1u.elements else ERROR_T,
+                        )
                 self.error("Concat requires two strings, two bytes, or two lists", pos)
             return STRING_T
 

--- a/tongues/src/taytsh/parse.py
+++ b/tongues/src/taytsh/parse.py
@@ -39,6 +39,7 @@ from .ast import (
     TMatchCase,
     TMatchStmt,
     TModule,
+    TModuleItem,
     TNilLit,
     TOpAssignStmt,
     TOptionalType,
@@ -254,7 +255,7 @@ class Parser:
     # ── Top Level ────────────────────────────────────────────
 
     def parse_program(self) -> TModule:
-        decls: list[TDecl] = []
+        decls: list[TModuleItem] = []
         strict_math = False
         strict_tostring = False
         seen_decl = False


### PR DESCRIPTION
## Summary

- Replace tuple returns with dataclasses in `lowering.py` isinstance chain extraction (fixes 14 tuple-unpack errors where `_lower_tuple_assign` falls back to `int`)
- Rename variables to avoid type conflicts: `inner`→`sorted_arg` in perl.py, `arg_strs`→`joined_args` in ruby.py, `a`→`va` in ast.py
- Rewrite `split("{}", 1)` unpack to index/slice in ruby.py
- Inline `r = stmt.iterable` to preserve isinstance narrowing in ruby.py
- Fix `list[TDecl]`→`list[TModuleItem]` collection invariance in parse.py
- Add `isinstance(TupleT)` guard before accessing `.elements` in check.py