### PR TITLE
Fix VSCode extension to match Taytsh spec

### DIFF
--- a/editors/vscode/samples/showcase.ty
+++ b/editors/vscode/samples/showcase.ty
@@ -16,8 +16,8 @@ interface Value {}
 struct IntVal : Value {
     n: int
 
-    fn IsEven(self) -> bool {
-        return self.n % 2 == 0
+    fn IsEven(this) -> bool {
+        return this.n % 2 == 0
     }
 }
 

--- a/editors/vscode/syntaxes/taytsh.tmLanguage.json
+++ b/editors/vscode/syntaxes/taytsh.tmLanguage.json
@@ -150,8 +150,8 @@
           "name": "storage.type.generic.taytsh"
         },
         {
-          "match": "\\bself\\b",
-          "name": "variable.language.self.taytsh"
+          "match": "\\bthis\\b",
+          "name": "variable.language.this.taytsh"
         }
       ]
     },
@@ -160,7 +160,7 @@
       "name": "keyword.control.taytsh"
     },
     "operators": {
-      "match": "(->|=>|\\?\\:|\\|\\||&&|==|!=|<=|>=|<<=|>>=|<<|>>|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|[+\\-*/%&|^~!<>?:=])",
+      "match": "(->|=>|\\?\\:|\\|\\||&&|==|!=|<=|>=|<<=|>>=|>>>|<<|>>|\\+=|-=|\\*=|/=|%=|&=|\\|=|\\^=|[+\\-*/%&|^~!<>?:=])",
       "name": "keyword.operator.taytsh"
     }
   }


### PR DESCRIPTION
## Summary
- Replace `self` with `this` in tmLanguage grammar and showcase sample (spec uses `this` as method receiver; `self` is not in the language)
- Add `>>>` (logical right shift, strict math) to operator highlighting regex