### PR TITLE
Add ListFrom builtin

### DIFF
--- a/tongues/src/backend/perl.py
+++ b/tongues/src/backend/perl.py
@@ -1892,6 +1892,8 @@ class _PerlEmitter:
             if isinstance(typ, TListType) and _is_string_type(typ.element):
                 return "[sort @{" + self._a(args, 0) + "}]"
             return "[sort { $a <=> $b } @{" + self._a(args, 0) + "}]"
+        if name == "ListFrom":
+            return "[@{" + self._deref_safe(self._a(args, 0)) + "}]"
         if name == "Reversed":
             return "[reverse @{" + self._a(args, 0) + "}]"
         if name == "Map":

--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -1676,6 +1676,8 @@ class _PythonEmitter:
             if self.strict_math and self._is_float_list(args[0].value):
                 return "strict_sorted_f64(" + self._a(args, 0) + ")"
             return "sorted(" + self._a(args, 0) + ")"
+        if name == "ListFrom":
+            return "list(" + self._a(args, 0) + ")"
         if name == "Reversed":
             return "list(reversed(" + self._a(args, 0) + "))"
         if name == "Reverse":

--- a/tongues/src/backend/ruby.py
+++ b/tongues/src/backend/ruby.py
@@ -1900,6 +1900,8 @@ class _RubyEmitter:
             if self.strict_math and self._is_float_list(args[0].value):
                 return "strict_sorted_f64(" + self._a(args, 0) + ")"
             return self._a(args, 0) + ".sort"
+        if name == "ListFrom":
+            return self._a(args, 0) + ".dup"
         if name == "Reversed":
             return self._a(args, 0) + ".reverse"
         if name == "Map":

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -2472,15 +2472,7 @@ def _lower_name_call(
             # list(set) → Sorted(set)
             if isinstance(arg_type, SetType):
                 return _make_call(pos, "Sorted", [_lower_expr(args[0], env, ctx)])
-            arg = _lower_expr(args[0], env, ctx)
-            # list(xs) → xs[0:Len(xs)]
-            return TSlice(
-                pos,
-                arg,
-                TIntLit(pos, 0, "0", _EMPTY_ANN),
-                _make_call(pos, "Len", [arg]),
-                _EMPTY_ANN,
-            )
+            return _make_call(pos, "ListFrom", [_lower_expr(args[0], env, ctx)])
     if fname == "bytes":
         if len(args) == 0:
             return TBytesLit(pos, b"", _EMPTY_ANN)

--- a/tongues/src/taytsh/check.py
+++ b/tongues/src/taytsh/check.py
@@ -986,6 +986,8 @@ BUILTIN_NAMES: set[str] = {
     "SetFromList",
     # String to char list
     "Chars",
+    # List from iterable
+    "ListFrom",
     # Mutation
     "ReplaceSlice",
     # Nil check
@@ -4245,6 +4247,20 @@ class Checker:
             if t is not None and not type_eq(t, STRING_T):
                 self.error("Chars requires string argument", pos)
             return ListT(kind="list", element=STRING_T)
+
+        if name == "ListFrom":
+            if not _bctx_require(ctx, 1):
+                return None
+            t = _bctx_arg(ctx, 0)
+            if t is not None:
+                tu = _unwrap_nil_union(t)
+                if isinstance(tu, ListT):
+                    return tu
+                if isinstance(tu, SetT):
+                    return ListT(kind="list", element=tu.element)
+                if tu.kind != TY_ERROR:
+                    self.error("ListFrom requires list or set argument", pos)
+            return None
 
         # ── Repeat ──
         if name == "Repeat":

--- a/tongues/src/taytsh/compiler.py
+++ b/tongues/src/taytsh/compiler.py
@@ -230,6 +230,7 @@ BUILTIN_TABLE: list[str] = [
     "Keys",
     "Len",
     "ListCompare",
+    "ListFrom",
     "Lower",
     "Map",
     "MapFromKeys",

--- a/tongues/src/taytsh/treewalker.py
+++ b/tongues/src/taytsh/treewalker.py
@@ -585,6 +585,7 @@ _RESERVED_BINDINGS: set[str] = {
     "IndexOf",
     "Reversed",
     "Sorted",
+    "ListFrom",
     "Map",
     "Get",
     "Delete",
@@ -3480,6 +3481,15 @@ def _bi_chars(rt: Runtime, args: list[Value]) -> Value:
     return VList(elems, ListT(kind="list", element=STRING_T))
 
 
+def _bi_list_from(rt: Runtime, args: list[Value]) -> Value:
+    xs = args[0]
+    if isinstance(xs, VList):
+        return VList(list(xs.elements), xs.typ)
+    if isinstance(xs, VSet):
+        return VList(list(xs.elements), ListT(kind="list", element=xs.typ.element))
+    raise TaytshRuntimeFault("ListFrom expects list or set", None)
+
+
 def _bi_zip(rt: Runtime, args: list[Value]) -> Value:
     a = args[0]
     b = args[1]
@@ -3821,6 +3831,8 @@ def _dispatch_builtin(rt: Runtime, name: str, args: list[Value]) -> Value:
         return _bi_set_from_list(rt, args)
     if name == "Chars":
         return _bi_chars(rt, args)
+    if name == "ListFrom":
+        return _bi_list_from(rt, args)
     if name == "WriteOut":
         return _bi_write_out(rt, args)
     if name == "WriteErr":
@@ -3934,6 +3946,7 @@ _BUILTIN_NAMES_RT: set[str] = {
     "Zip",
     "SetFromList",
     "Chars",
+    "ListFrom",
     "WriteOut",
     "WriteErr",
     "WritelnOut",

--- a/tongues/src/taytsh/vm.py
+++ b/tongues/src/taytsh/vm.py
@@ -566,6 +566,8 @@ class _BuiltinDispatch:
             return self._set_difference(args)
         if name == "SetFromList":
             return self._set_from_list(args)
+        if name == "ListFrom":
+            return self._list_from(args)
         if name == "Abs":
             return self._abs(args)
         if name == "Min":
@@ -1482,6 +1484,13 @@ class _BuiltinDispatch:
                     result.append(item)
             return VSet(result)
         return VSet([])
+
+    def _list_from(self, args: list[Val]) -> Val:
+        if isinstance(args[0], VList):
+            return VList(list(args[0].items))
+        if isinstance(args[0], VSet):
+            return VList(list(args[0].items))
+        return VList([])
 
     # ── Misc builtins ─────────────────────────────────────────
 

--- a/tongues/tests/10_lowering/builtins.tests
+++ b/tongues/tests/10_lowering/builtins.tests
@@ -134,5 +134,5 @@ Round(x, 2)
 def f(xs: list[int]) -> list[int]:
     return list(xs)
 ---
-xs[0:Len(xs)]
+ListFrom(xs)
 ---


### PR DESCRIPTION
## Summary

- `list(x)` was lowered to `x[0:Len(x)]` (slice copy), which only works on lists — fails on `dict_keys` views and other iterables
- Adds a dedicated `ListFrom` builtin that correctly materializes any list or set to a new list
- Implemented across lowering, checker, all three backend emitters (Python/Perl/Ruby), treewalker, VM, and compiler