### PR TITLE
Fix dict spread and error message loss in self-transpilation

### DIFF
--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -549,7 +549,7 @@ class _PythonEmitter:
         if len(decl.fields) > 0:
             msg_field: TFieldDecl | None = None
             for fld in decl.fields:
-                if fld.name == "message":
+                if fld.name == "message" or fld.name == "msg":
                     msg_field = fld
                     break
             if msg_field is not None:

--- a/tongues/src/backend/ruby.py
+++ b/tongues/src/backend/ruby.py
@@ -675,7 +675,7 @@ class _RubyEmitter:
         if is_error:
             msg_field: TFieldDecl | None = None
             for f in fields:
-                if f.name == "message":
+                if f.name == "message" or f.name == "msg":
                     msg_field = f
                     break
             if msg_field is not None:

--- a/tongues/src/taytsh/parse.py
+++ b/tongues/src/taytsh/parse.py
@@ -244,10 +244,14 @@ class Parser:
             if self.peek(1).value == "@":
                 self.advance()
                 self.advance()
-                semantic.update(self._parse_ann_entries())
+                entries = self._parse_ann_entries()
+                for k in entries:
+                    semantic[k] = entries[k]
             elif self.peek(1).value == "[":
                 self.advance()
-                advisory.update(self._parse_ann_entries())
+                entries = self._parse_ann_entries()
+                for k in entries:
+                    advisory[k] = entries[k]
             else:
                 break
         return advisory, semantic
@@ -273,8 +277,10 @@ class Parser:
                         raise self.error("unknown annotation '" + key + "'")
                 semantic: dict[str, str] = {}
                 seen_decl = True
-            decl.annotations.update(advisory)
-            decl.annotations.update(semantic)
+            for k in advisory:
+                decl.annotations[k] = advisory[k]
+            for k in semantic:
+                decl.annotations[k] = semantic[k]
             decls.append(decl)
         module = TModule(decls)
         module.strict_math = strict_math
@@ -477,7 +483,11 @@ class Parser:
 
     def parse_stmt(self) -> TStmt:
         advisory, semantic = self.parse_annotations()
-        ann: dict[str, str] = {**advisory, **semantic}
+        ann: dict[str, str] = {}
+        for k in advisory:
+            ann[k] = advisory[k]
+        for k in semantic:
+            ann[k] = semantic[k]
         tok = self.current()
         if tok.value == "let":
             stmt: TStmt = self.parse_let_stmt()
@@ -505,8 +515,8 @@ class Parser:
             stmt = self.parse_throw_stmt()
         else:
             stmt = self.parse_expr_stmt()
-        if ann:
-            stmt.annotations.update(ann)
+        for k in ann:
+            stmt.annotations[k] = ann[k]
         return stmt
 
     def parse_let_stmt(self) -> TLetStmt:
@@ -830,7 +840,11 @@ class Parser:
     def parse_postfix(self) -> TExpr:
         """Postfix = Annotation* Primary ( Suffix )*"""
         advisory, semantic = self.parse_annotations()
-        ann: dict[str, str] = {**advisory, **semantic}
+        ann: dict[str, str] = {}
+        for k in advisory:
+            ann[k] = advisory[k]
+        for k in semantic:
+            ann[k] = semantic[k]
         expr = self.parse_primary()
         while True:
             if self.at("."):
@@ -862,8 +876,8 @@ class Parser:
                 expr = TCall(expr.pos, expr, args, {})
             else:
                 break
-        if ann:
-            expr.annotations.update(ann)
+        for k in ann:
+            expr.annotations[k] = ann[k]
         return expr
 
     def parse_arg_list(self) -> list[TArg]:


### PR DESCRIPTION
## Summary

- **Dict spread elimination**: Replace `{**a, **b}` and `.update()` in the Taytsh parser with explicit `for k in d: target[k] = d[k]` loops. The lowering's `get_nodes` skips `None` keys (which represent `**` spreads in the Python AST), so dict spreads produce empty dicts after transpilation. `.update()` is equally broken — it lowers to `Merge(a, b)` which the Python backend emits as `{**a, **b}`.

- **Error `msg` field recognition**: Python and Ruby backends now recognize `"msg"` (not just `"message"`) as the error field to pass to `super().__init__()`. Without this, error classes like `ParseError(msg, line, col)` call `super().__init__()` with no argument, making `str(e)` empty and causing the test runner to see zero errors.

Fixes 204 self-transpilation test failures (532 → 328).