### PR TITLE
Fix set.update() on parameter in callgraph throws propagation

### DIFF
--- a/tongues/src/middleend/callgraph.py
+++ b/tongues/src/middleend/callgraph.py
@@ -92,10 +92,9 @@ _STRICT_INT_OPS = {"+", "-", "*"}
 def _add_throws(
     types: set[str], throws: set[str], caught_filter: set[str] | None
 ) -> None:
-    if caught_filter is not None:
-        throws.update(types - caught_filter)
-    else:
-        throws.update(types)
+    for t in types:
+        if caught_filter is None or t not in caught_filter:
+            throws.add(t)
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Replace `set.update()` with a `for`/`add` loop in `_add_throws` since the transpiler lowers `.update()` to reassignment, which silently breaks when the target is a function parameter
- Without this, the transpiled callgraph analysis never propagated throw types, leaving all `throws` annotations empty
- Eliminates 92 self-transpiled test failures (240 → 148)