### PR TITLE
Narrow is not None through and/or in BoolOp expressions

### DIFF
--- a/tongues/src/frontend/inference.py
+++ b/tongues/src/frontend/inference.py
@@ -1090,8 +1090,25 @@ def _synth_boolop(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
     values = get_nodes(node, "values")
     if len(values) == 0:
         return ANY_TYPE
-    last = values[len(values) - 1]
-    return _synth_expr(last, env, ctx)
+    op = get_node(node, "op")
+    op_t = get_str(op, "_type")
+    if op_t == "And":
+        work = env.copy()
+        j = 0
+        while j < len(values) - 1:
+            dummy = env.copy()
+            _extract_narrowing(values[j], work, dummy, ctx)
+            j += 1
+        return _synth_expr(values[len(values) - 1], work, ctx)
+    if op_t == "Or":
+        work = env.copy()
+        j = 0
+        while j < len(values) - 1:
+            dummy = env.copy()
+            _extract_narrowing(values[j], dummy, work, ctx)
+            j += 1
+        return _synth_expr(values[len(values) - 1], work, ctx)
+    return _synth_expr(values[len(values) - 1], env, ctx)
 
 
 def _synth_ifexp(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
@@ -1741,6 +1758,31 @@ def _validate_expr_calls(
         return
     if t == "UnaryOp":
         _validate_expr_calls(get_node(node, "operand"), env, ctx, lineno)
+        return
+    if t == "BoolOp":
+        op = get_node(node, "op")
+        op_t = get_str(op, "_type")
+        values = get_nodes(node, "values")
+        if op_t == "And":
+            work = env.copy()
+            j = 0
+            while j < len(values):
+                _validate_expr_calls(values[j], work, ctx, lineno)
+                if j < len(values) - 1:
+                    dummy = env.copy()
+                    _extract_narrowing(values[j], work, dummy, ctx)
+                j += 1
+            return
+        if op_t == "Or":
+            work = env.copy()
+            j = 0
+            while j < len(values):
+                _validate_expr_calls(values[j], work, ctx, lineno)
+                if j < len(values) - 1:
+                    dummy = env.copy()
+                    _extract_narrowing(values[j], dummy, work, ctx)
+                j += 1
+            return
         return
 
 

--- a/tongues/tests/09_inference/callables.tests
+++ b/tongues/tests/09_inference/callables.tests
@@ -323,3 +323,36 @@ def main() -> int:
 ---
 error: argument 1 has type str, expected int
 ---
+
+=== call with is not None guard in and ok
+def check(x: int) -> bool:
+    return x > 0
+def f(x: int | None) -> bool:
+    if x is not None and check(x):
+        return True
+    return False
+---
+ok
+---
+
+=== call with is None guard in or ok
+def check(x: int) -> bool:
+    return x > 0
+def f(x: int | None) -> bool:
+    if x is None or check(x):
+        return True
+    return False
+---
+ok
+---
+
+=== call in and without guard not allowed
+def check(x: int) -> bool:
+    return x > 0
+def f(x: int | None) -> bool:
+    if True and check(x):
+        return True
+    return False
+---
+error: argument 1 has type int | None, expected int
+---

--- a/tongues/tests/09_inference/narrowing.tests
+++ b/tongues/tests/09_inference/narrowing.tests
@@ -335,3 +335,55 @@ def f(x: int | str) -> None:
 ---
 reveal:3 = int
 ---
+
+=== and chain narrows both sides
+def f(x: int | None, y: str | None) -> int:
+    if x is not None and y is not None:
+        reveal_type(x)
+        reveal_type(y)
+        return x + len(y)
+    return 0
+---
+reveal:3 = int
+reveal:4 = str
+---
+
+=== and chain three vars
+def f(a: int | None, b: int | None, c: int | None) -> int:
+    if a is not None and b is not None and c is not None:
+        reveal_type(a)
+        reveal_type(b)
+        reveal_type(c)
+        return a + b + c
+    return 0
+---
+reveal:3 = int
+reveal:4 = int
+reveal:5 = int
+---
+
+=== and chain isinstance plus is not None
+def f(x: int | str, y: int | None) -> int:
+    if isinstance(x, int) and y is not None:
+        reveal_type(x)
+        reveal_type(y)
+        return x + y
+    return 0
+---
+reveal:3 = int
+reveal:4 = int
+---
+
+=== isinstance short-circuit and allows attribute access
+class A:
+    pass
+class B(A):
+    flag: int
+def f(x: A) -> int:
+    if isinstance(x, B) and x.flag > 0:
+        return x.flag
+    return 0
+---
+ok
+---
+

--- a/tongues/tests/09_inference/narrowing.tests.pending
+++ b/tongues/tests/09_inference/narrowing.tests.pending
@@ -88,43 +88,6 @@ def f() -> str:
 ok
 ---
 
-=== and chain narrows both sides
-def f(x: int | None, y: str | None) -> int:
-    if x is not None and y is not None:
-        reveal_type(x)
-        reveal_type(y)
-        return x + len(y)
-    return 0
----
-reveal:3 = int
-reveal:4 = str
----
-
-=== and chain three vars
-def f(a: int | None, b: int | None, c: int | None) -> int:
-    if a is not None and b is not None and c is not None:
-        reveal_type(a)
-        reveal_type(b)
-        reveal_type(c)
-        return a + b + c
-    return 0
----
-reveal:3 = int
-reveal:4 = int
-reveal:5 = int
----
-
-=== and chain isinstance plus is not None
-def f(x: int | str, y: int | None) -> int:
-    if isinstance(x, int) and y is not None:
-        reveal_type(x)
-        reveal_type(y)
-        return x + y
-    return 0
----
-reveal:3 = int
-reveal:4 = int
----
 
 === or isinstance extracts union
 class A:


### PR DESCRIPTION
## Summary
- Apply type narrowing between operands in `_synth_boolop` so guards like `x is not None and f(x)` see `x` as the narrowed type
- Add BoolOp handler to `_validate_expr_calls` with the same narrowing logic for call argument validation
- Promote 4 BoolOp narrowing tests from pending, add 3 new call validation tests

Fixes #83