### PR TITLE
Check in .envrc for direnv-based toolchain pinning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,33 @@
+# Tongues development environment
+# Run `just versions` to compare local vs Docker-expected versions
+
+# Pinned versions (matching Docker)
+export PATH="/opt/homebrew/opt/gcc@13/bin:$PATH"
+export PATH="/opt/homebrew/opt/dotnet@8/bin:$PATH"
+export DOTNET_ROOT="/opt/homebrew/opt/dotnet@8/libexec"
+export PATH="/opt/homebrew/opt/go@1.21/bin:$PATH"
+export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"
+export PATH="/opt/homebrew/opt/php@8.3/bin:$PATH"
+export PATH="/opt/homebrew/opt/python@3.12/bin:$PATH"
+export PATH="/opt/homebrew/opt/ruby@3.3/bin:$PATH"
+export PATH="/opt/homebrew/lib/ruby/gems/3.3.0/bin:$PATH"
+
+# Manual installs to /opt
+export PATH="/opt/node-21/bin:$PATH"
+export PATH="/opt/perl-5.38/bin:$PATH"
+export PATH="$HOME/perl5/bin:$PATH"
+export PATH="$HOME/.dotnet/tools:$PATH"
+
+# Rustup-managed (1.75.0)
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Manual installs (pinned to Docker versions)
+export PATH="/opt/dart-3.2.6/bin:$PATH"
+export PATH="/opt/homebrew/opt/zig@0.14/bin:$PATH"
+# Swift 6.x via xcrun (uses Xcode's bundled Swift)
+
+# Latest versions (no pinned available)
+export PATH="/opt/homebrew/opt/lua/bin:$PATH"
+
+# Local symlinks (must be last to take priority)
+export PATH="$PWD/.direnv/bin:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__/
 .ruff_cache/
 .out/
 .php-cs-fixer.cache
-.envrc
 .direnv/
 editors/vscode/*.vsix
 *.egg-info


### PR DESCRIPTION
## Summary
- Remove `.envrc` from `.gitignore` and check it in
- Pins PATH entries for all 15 target runtimes matching Docker versions
- Requires `direnv` with `eval "$(direnv hook zsh)"` in shell rc