### PR TITLE
Add .direnv/bin symlinks for pinned tool versions

### DIFF
--- a/.direnv/bin/gcc
+++ b/.direnv/bin/gcc
@@ -1,0 +1,1 @@
+/opt/homebrew/opt/gcc@13/bin/gcc-13

--- a/.direnv/bin/python
+++ b/.direnv/bin/python
@@ -1,0 +1,1 @@
+/opt/homebrew/opt/python@3.12/bin/python3.12

--- a/.direnv/bin/python3
+++ b/.direnv/bin/python3
@@ -1,0 +1,1 @@
+/opt/homebrew/opt/python@3.12/bin/python3.12

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .ruff_cache/
 .out/
 .php-cs-fixer.cache
-.direnv/
+.direnv/*
+!.direnv/bin/
 editors/vscode/*.vsix
 *.egg-info


### PR DESCRIPTION
## Summary
- Track `.direnv/bin/` symlinks in git to ensure `just versions` passes on macOS
- Symlinks override system gcc/python with Homebrew-pinned versions:
  - `gcc` → `/opt/homebrew/opt/gcc@13/bin/gcc-13`
  - `python` → `/opt/homebrew/opt/python@3.12/bin/python3.12`
  - `python3` → `/opt/homebrew/opt/python@3.12/bin/python3.12`

Note: These symlinks are macOS/Homebrew-specific. Linux/CI environments use Docker where versions are pinned directly.