### PR TITLE
Fix rune in tuple-of-strings rejected by Taytsh checker

### DIFF
--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -2232,8 +2232,15 @@ def _lower_in_expr(
         left = _lower_expr(left_node, env, ctx)
         if not elts:
             return TBoolLit(pos, False, {})
+        left_type = _infer_expr_type(left_node, env, ctx)
+        lt_rune = _is_type_dict(left_type, ["rune"])
         parts: list[TExpr] = []
         for e in elts:
+            if lt_rune:
+                rch = _single_char_str_value(e)
+                if rch is not None:
+                    parts.append(TBinaryOp(pos, "==", left, TRuneLit(pos, rch, {}), {}))
+                    continue
             right = _lower_expr(e, env, ctx)
             parts.append(TBinaryOp(pos, "==", left, right, {}))
         result: TExpr = parts[0]

--- a/tongues/tests/10_lowering/operators.tests
+++ b/tongues/tests/10_lowering/operators.tests
@@ -262,6 +262,46 @@ def f(i: int) -> bool:
 op == "add"
 ---
 
+=== rune in tuple promotes to rune literals
+def f(s: str) -> bool:
+    for ch in s:
+        if ch in ("$", "@"):
+            return True
+    return False
+---
+== '$' || ch == '@'
+---
+
+=== rune not in tuple promotes to rune literals
+def f(s: str) -> bool:
+    for ch in s:
+        if ch not in ("a", "b"):
+            return True
+    return False
+---
+!(ch == 'a' || ch == 'b')
+---
+
+=== rune in single-element tuple promotes to rune literal
+def f(s: str) -> bool:
+    for ch in s:
+        if ch in ("x",):
+            return True
+    return False
+---
+ch == 'x'
+---
+
+=== rune in tuple with escape char promotes to rune literal
+def f(s: str) -> bool:
+    for ch in s:
+        if ch in ("\n", "\t"):
+            return True
+    return False
+---
+== '\n' || ch == '\t'
+---
+
 === field from narrowed optional used in dict containment
 class Base:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- Apply single-char string → rune promotion in `_lower_in_expr` tuple desugaring, matching the existing behavior of `_lower_single_compare` for direct `==` comparisons
- Add lowering tests for `in`, `not in`, single-element tuple, and escape characters

Closes #105