### PR TITLE
Fix VM compiler opcodes for global let variables

### DIFF
--- a/tongues/src/taytsh/compiler.py
+++ b/tongues/src/taytsh/compiler.py
@@ -459,6 +459,7 @@ class Compiler:
         self._interface_index: dict[str, int] = {}
         self.entry_index: int = -1
         # Checker state
+        self.global_let_types: dict[str, Type] = {}
         self.checker_types: dict[str, Type] = {}
         self.checker_functions: dict[str, FnT] = {}
         self.fn_param_names: dict[str, list[str]] = {}
@@ -491,6 +492,7 @@ class Compiler:
                 self._ensure_global(decl.name)
             elif isinstance(decl, TLetStmt):
                 self._ensure_global(decl.name)
+                self.global_let_types[decl.name] = self._resolve_ttype(decl.typ)
         # Compile all top-level functions
         for decl in module.decls:
             if isinstance(decl, TFnDecl):
@@ -1666,6 +1668,9 @@ class Compiler:
             fn = self.checker_functions.get(expr.name)
             if fn is not None:
                 return fn
+            glt = self.global_let_types.get(expr.name)
+            if glt is not None:
+                return glt
             return VOID_T
         if isinstance(expr, TBinaryOp):
             op = expr.op

--- a/tongues/tests/taytsh/app/top_level_let.ty
+++ b/tongues/tests/taytsh/app/top_level_let.ty
@@ -15,6 +15,8 @@ fn MakeTable() -> list[int] {
 
 let TABLE: list[int] = MakeTable()
 
+let PI: float = 3.14159
+let TAU: float = 6.28318
 fn Main() -> void {
     Assert(MAX_SIZE == 256)
     Assert(GREETING == "hello")
@@ -25,4 +27,23 @@ fn Main() -> void {
     Assert(TABLE[0] == 0)
     Assert(TABLE[1] == 1)
     Assert(TABLE[4] == 16)
+
+    -- float comparisons on global lets (#122)
+    Assert(PI > 3.0)
+    Assert(PI < 4.0)
+    Assert(TAU > PI)
+
+    -- float arithmetic on global lets (#122)
+    Assert(PI + PI > 6.28)
+    Assert(TAU - PI > 3.14)
+    Assert(PI * 2.0 > 6.28)
+
+    -- int arithmetic on global lets (#122)
+    Assert(MAX_SIZE + 1 == 257)
+    Assert(MAX_SIZE * 2 == 512)
+    Assert(MAX_SIZE - 6 == 250)
+
+    -- negation on global let (#122)
+    Assert(-PI < 0.0)
+
 }


### PR DESCRIPTION
## Summary

- `_resolve_expr_type`'s `TVar` branch had no path for global let bindings, falling through to `VOID_T` and selecting wrong type-specialized opcodes (e.g. `OP_CMP_INT` for a `float` global)
- Store resolved types for top-level lets in a `global_let_types` dict and consult it in the `TVar` lookup chain
- Add regression tests: float comparisons, float arithmetic, int arithmetic, and negation on global lets

Closes #122