### PR TITLE
Narrow optional attributes after direct field assignment

### DIFF
--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -1843,6 +1843,10 @@ def _cfg_merge_env(
             env.types[k] = env_a.types[k]
         elif in_b and not both_only:
             env.types[k] = env_b.types[k]
+    gkeys_a = list(env_a.guarded_attrs)
+    for gk in gkeys_a:
+        if gk in env_b.guarded_attrs:
+            env.guarded_attrs.add(gk)
 
 
 # ---------------------------------------------------------------------------
@@ -2069,6 +2073,10 @@ def _validate_assign(
             _validate_subscript_assign(target, val_type, env, ctx, lineno)
         elif _is_type(target, ["Attribute"]):
             _synth_expr(target, env, ctx)
+            if not isinstance(val_type, OptionalType):
+                path = _attr_path(target)
+                if path:
+                    env.guard_attr(path)
 
 
 def _is_empty_collection(node: ASTNode) -> bool:

--- a/tongues/tests/frontend/pycheck/narrowing.tests
+++ b/tongues/tests/frontend/pycheck/narrowing.tests
@@ -5323,6 +5323,20 @@ def f(a: A) -> int:
 ---
 error: None
 ---
+=== attribute narrowed by direct assignment in if body
+from dataclasses import dataclass
+@dataclass
+class Obj:
+    name: str | None
+def f(o: Obj) -> str:
+    if o.name is None:
+        o.name = "hello"
+    return o.name.upper()
+---
+ok
+---
+
+
 === attribute guard on wrong field fails
 from dataclasses import dataclass
 @dataclass


### PR DESCRIPTION
## Summary
- When assigning a non-optional value to an attribute (e.g. `o.name = "hello"`), mark that attribute path as guarded so subsequent access doesn't require a re-check
- Intersect `guarded_attrs` from both branches at CFG merge points so guards survive joins
- Adds a test for the `if o.field is None: o.field = val` pattern

Closes #137