### PR TITLE
Support type(x) is/== T narrowing in pycheck

### DIFF
--- a/tongues/src/frontend/bind.py
+++ b/tongues/src/frontend/bind.py
@@ -258,6 +258,17 @@ def is_singleton_constant(node: ASTNode) -> bool:
     return isinstance(val, JNull) or isinstance(val, JBool)
 
 
+def _is_type_call(node: ASTNode) -> bool:
+    """Check if node is type(x) — a Call to Name('type') with one arg."""
+    if get_str(node, "_type") != "Call":
+        return False
+    func = get_node(node, "func")
+    if get_str(func, "_type") != "Name" or get_str(func, "id") != "type":
+        return False
+    args = get_nodes(node, "args")
+    return len(args) == 1
+
+
 def get_attr_name(node: ASTNode) -> str | None:
     """Get attr from Attribute node."""
     if get_str(node, "_type") == "Attribute":
@@ -328,6 +339,7 @@ class Verifier:
         self.in_for_iter: bool = False
         self.in_for_body: bool = False  # For structural recursion (yield allowed)
         self.in_file_open: bool = False  # Inside validated with-open block
+        self.in_type_compare: bool = False  # type(x) is/== T comparison
         # Variables guarded by `if var:` condition (for tuple unpacking)
         self.guarded_vars: set[str] = set()
 
@@ -738,7 +750,8 @@ class Verifier:
         func_name = get_name_id(func)
         # Check banned builtins
         if func_name is not None and func_name in BANNED_BUILTINS:
-            self.error(node, "builtin", func_name + "() is not allowed")
+            if not (func_name == "type" and self.in_type_compare):
+                self.error(node, "builtin", func_name + "() is not allowed")
         # open() only allowed inside validated with-open
         if func_name == "open" and not self.in_file_open:
             self.error(node, "builtin", "open() only allowed in with-open idiom")
@@ -831,15 +844,21 @@ class Verifier:
                 if not is_singleton_constant(left) and not is_singleton_constant(
                     comparator
                 ):
-                    self.error(
-                        node,
-                        "reflection",
-                        "is/is not only allowed with None/True/False",
-                    )
+                    if not _is_type_call(left):
+                        self.error(
+                            node,
+                            "reflection",
+                            "is/is not only allowed with None/True/False",
+                        )
             left = comparator
             i += 1
-        # Visit children
+        # Visit children — allow type() in comparisons
+        has_type_call = _is_type_call(get_node(node, "left"))
+        if has_type_call:
+            self.in_type_compare = True
         self.visit(get_node(node, "left"))
+        if has_type_call:
+            self.in_type_compare = False
         for comp in comparators:
             self.visit(comp)
 
@@ -1432,6 +1451,7 @@ ALLOWED_BUILTINS: set[str] = {
     "sorted",
     # Type check
     "isinstance",
+    "type",
     # Iteration
     "range",
     "enumerate",

--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -654,6 +654,8 @@ def _synth_name(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
         return FuncType([ANY_TYPE], SliceType(ANY_TYPE))
     if name == "isinstance":
         return FuncType([ANY_TYPE, ANY_TYPE], BOOL_TYPE)
+    if name == "type":
+        return FuncType([ANY_TYPE], ANY_TYPE)
     if name == "print":
         return FuncType([ANY_TYPE], VOID_TYPE)
     if name == "range":
@@ -1099,6 +1101,8 @@ def _synth_name_call(
         return INT_TYPE
     if fname == "isinstance":
         return BOOL_TYPE
+    if fname == "type":
+        return ANY_TYPE
     if fname == "hash":
         return INT_TYPE
     if fname == "range":
@@ -3234,6 +3238,37 @@ def _narrow_compare(
     comp_is_none = _is_type(comp, ["Constant"]) and _is_null_value(comp)
     if _is_type(comp, ["Constant"]):
         _synth_expr(comp, then_env, ctx)
+    # type(x) is/== T narrowing
+    if (
+        op_type in ("Is", "Eq", "IsNot", "NotEq")
+        and _is_type(left, ["Call"])
+        and _is_type(comp, ["Name"])
+    ):
+        func = get_node(left, "func")
+        call_args = get_nodes(left, "args")
+        if (
+            func
+            and _is_type(func, ["Name"])
+            and get_str(func, "id") == "type"
+            and len(call_args) == 1
+            and _is_type(call_args[0], ["Name"])
+        ):
+            var_name = get_str(call_args[0], "id")
+            class_name = get_str(comp, "id")
+            if var_name and class_name:
+                sig_errors: list[TypeCollectError] = []
+                resolved = py_type_to_type_dict(
+                    class_name, ctx.known_classes, sig_errors, 0, 0
+                )
+                positive = op_type in ("Is", "Eq")
+                pos_env = then_env if positive else else_env
+                neg_env = else_env if positive else then_env
+                pos_env.narrow(var_name, resolved)
+                neg_type = neg_env.get_type(var_name)
+                if neg_type is not None:
+                    remaining = remove_from_union(neg_type, [resolved])
+                    neg_env.narrow(var_name, remaining)
+                return
     if op_type == "Is" and comp_is_none:
         if _is_type(left, ["Name"]):
             name = get_str(left, "id")

--- a/tongues/tests/frontend/pycheck/narrowing.tests
+++ b/tongues/tests/frontend/pycheck/narrowing.tests
@@ -5976,3 +5976,98 @@ def f(x: int) -> None:
 ---
 error: reveal_type: expected 'str', got 'int'
 ---
+
+=== type(x) is narrows to exact class
+from dataclasses import dataclass
+@dataclass
+class Animal:
+    name: str
+@dataclass
+class Dog(Animal):
+    tricks: int
+def f(x: Animal) -> None:
+    if type(x) is Dog:
+        reveal_type(x)
+---
+reveal:10 = Dog
+---
+
+=== type(x) == narrows to exact class
+from dataclasses import dataclass
+@dataclass
+class Base:
+    val: int
+@dataclass
+class Sub(Base):
+    extra: str
+def f(x: Base) -> None:
+    if type(x) == Sub:
+        reveal_type(x)
+---
+reveal:10 = Sub
+---
+
+=== type(x) is narrows union
+from dataclasses import dataclass
+@dataclass
+class A:
+    a_val: int
+@dataclass
+class B:
+    b_val: str
+def f(x: A | B) -> None:
+    if type(x) is A:
+        reveal_type(x)
+---
+reveal:10 = A
+---
+
+=== type(x) is narrows else branch of union
+from dataclasses import dataclass
+@dataclass
+class A:
+    a_val: int
+@dataclass
+class B:
+    b_val: str
+def f(x: A | B) -> None:
+    if type(x) is A:
+        reveal_type(x)
+    else:
+        reveal_type(x)
+---
+reveal:10 = A
+reveal:12 = B
+---
+
+=== type(x) is with early return narrows remainder
+from dataclasses import dataclass
+@dataclass
+class A:
+    a_val: int
+@dataclass
+class B:
+    b_val: str
+def f(x: A | B) -> None:
+    if type(x) is A:
+        return
+    reveal_type(x)
+---
+reveal:11 = B
+---
+
+=== type(x) is allows field access
+from dataclasses import dataclass
+@dataclass
+class Animal:
+    name: str
+@dataclass
+class Dog(Animal):
+    tricks: int
+def f(x: Animal) -> int:
+    if type(x) is Dog:
+        return x.tricks
+    return 0
+---
+ok
+---


### PR DESCRIPTION
Closes #142

## Summary
- Allow `type(x) is T`, `type(x) == T`, `type(x) is not T`, and `type(x) != T` in pycheck by relaxing the `is`/`is not` singleton gate and the `type()` builtin ban in `bind.py`
- Add narrowing logic in `_narrow_compare` that narrows the positive branch to the class type and removes it from the negative branch's union, mirroring `_narrow_isinstance`
- Register `type` as a known builtin in the checker so `type()` calls type-check without error
- Add 6 tests covering exact-class narrowing, `==` variant, union narrowing, else-branch narrowing, early-return narrowing, and field access after narrowing