### PR TITLE
Support `not in` narrowing for union types

### DIFF
--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -3414,6 +3414,25 @@ def _narrow_compare(
                         then_env.narrow(name, combine_types(in_yes))
                     if in_no:
                         else_env.narrow(name, combine_types(in_no))
+    if op_type == "NotIn":
+        if _is_type(left, ["Name"]):
+            name = get_str(left, "id")
+            if name and _is_type(comp, ["List", "Set", "Tuple"]):
+                elts = get_nodes(comp, "elts")
+                elem_kinds: set[str] = set()
+                for elt in elts:
+                    et = _synth_expr(elt, then_env, ctx)
+                    k = _prim_kind(et)
+                    if k:
+                        elem_kinds.add(k)
+                cur = then_env.get_type(name)
+                if cur is not None and isinstance(cur, UnionType) and elem_kinds:
+                    in_yes = [v for v in cur.variants if _prim_kind(v) in elem_kinds]
+                    in_no = [v for v in cur.variants if _prim_kind(v) not in elem_kinds]
+                    if in_no:
+                        then_env.narrow(name, combine_types(in_no))
+                    if in_yes:
+                        else_env.narrow(name, combine_types(in_yes))
 
 
 def _narrow_len_check(

--- a/tongues/tests/frontend/pycheck/narrowing.tests
+++ b/tongues/tests/frontend/pycheck/narrowing.tests
@@ -5954,6 +5954,24 @@ def f(x: int | str) -> int:
 ok
 ---
 
+=== not in operator narrows union type in else branch
+def f(x: int | str) -> str:
+    if x not in [1, 2, 3]:
+        return x
+    return ""
+---
+ok
+---
+
+=== not in narrows else branch to matching variants
+def f(x: int | str) -> int:
+    if x not in [1, 2, 3]:
+        return 0
+    return x
+---
+ok
+---
+
 === tuple union narrowed by length check
 def f(t: tuple[int, int] | tuple[str, str, str]) -> int:
     if len(t) == 2:


### PR DESCRIPTION
## Summary
- Add `NotIn` handler to `_narrow_compare` — inverse of the existing `In` handler
- `not in [...]` narrows the then-branch to non-matching variants and the else-branch to matching variants