### PR TITLE
Add regression tests for chained and/or narrowing

### DIFF
--- a/tongues/tests/frontend/pycheck/narrowing.tests
+++ b/tongues/tests/frontend/pycheck/narrowing.tests
@@ -6071,3 +6071,64 @@ def f(x: Animal) -> int:
 ---
 ok
 ---
+
+=== chained and narrows optional for comparison
+def f(x: int | None) -> None:
+    if x is not None and x > 0:
+        reveal_type(x)
+---
+reveal:3 = int
+---
+
+=== chained and narrows multiple optionals for comparison
+def f(x: int | None, y: int | None) -> None:
+    if x is not None and y is not None and x > 0 and x <= y:
+        reveal_type(x)
+        reveal_type(y)
+---
+reveal:3 = int
+reveal:4 = int
+---
+
+=== chained and narrows local annotated optionals
+def f() -> None:
+    x: int | None = None
+    y: int | None = None
+    x = 5
+    y = 10
+    if x is not None and y is not None and x > 0 and x <= y:
+        reveal_type(x)
+        reveal_type(y)
+---
+reveal:7 = int
+reveal:8 = int
+---
+
+=== chained and narrows for attribute access after guard
+from dataclasses import dataclass
+@dataclass
+class Foo:
+    val: int
+def f(x: Foo | None) -> None:
+    if x is not None and x.val > 0:
+        reveal_type(x)
+---
+reveal:7 = Foo
+---
+
+=== chained and with isinstance narrows for comparison
+def f(x: int | str) -> None:
+    if isinstance(x, int) and x > 0:
+        reveal_type(x)
+---
+reveal:3 = int
+---
+
+=== chained or guard narrows remainder
+def f(x: int | None, y: int | None) -> int:
+    if x is None or y is None:
+        return 0
+    return x + y
+---
+ok
+---


### PR DESCRIPTION
Closes #134

## Summary
- The chained `and` narrowing described in #134 already works correctly (likely fixed by recent narrowing PRs)
- Adds 6 regression tests covering: simple optional guard + comparison, multi-variable 4-way `and` chain, local annotated variables, attribute access after guard, `isinstance` through `and`, and `or` guard with early return