### PR TITLE
Allow isinstance with tuple of types

### DIFF
--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -1249,6 +1249,12 @@ class _PythonEmitter(Emitter):
                     + self._expr(expr.right)
                     + ")"
                 )
+        # isinstance tuple: IsType(x, A) || IsType(x, B) → isinstance(x, (A, B))
+        if op == "||" and expr.annotations.get("provenance") == "isinstance_tuple":
+            types: list[str] = []
+            obj = self._flatten_isinstance_tuple(expr, types)
+            if obj is not None:
+                return "isinstance(" + obj + ", (" + ", ".join(types) + "))"
         # chained comparison: a OP1 b && b OP2 c → a OP1 b OP2 c
         if op == "&&" and expr.annotations.get("provenance") == "chained_comparison":
             chained = self._chain_comparison(expr)
@@ -1321,6 +1327,31 @@ class _PythonEmitter(Emitter):
                 + " "
                 + self._expr(right.right)
             )
+        return None
+
+    def _flatten_isinstance_tuple(self, expr: TExpr, types: list[str]) -> str | None:
+        """Flatten IsType(x, A) || IsType(x, B) || ... into obj and type names."""
+        if isinstance(expr, TBinaryOp) and expr.op == "||":
+            obj = self._flatten_isinstance_tuple(expr.left, types)
+            rhs = expr.right
+            if (
+                isinstance(rhs, TCall)
+                and isinstance(rhs.func, TVar)
+                and rhs.func.name == "IsType"
+            ):
+                type_arg = rhs.args[1].value
+                if isinstance(type_arg, TStringLit):
+                    types.append(type_arg.value)
+                return obj
+        if (
+            isinstance(expr, TCall)
+            and isinstance(expr.func, TVar)
+            and expr.func.name == "IsType"
+        ):
+            type_arg = expr.args[1].value
+            if isinstance(type_arg, TStringLit):
+                types.append(type_arg.value)
+            return self._expr(expr.args[0].value)
         return None
 
     def _maybe_paren(self, expr: TExpr, parent_op: str, is_left: bool) -> str:

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -2764,7 +2764,8 @@ def _lower_name_call(
                     "IsType",
                     [lowered_arg, TStringLit(pos, tnames[ti], {})],
                 )
-                result_expr = TBinaryOp(pos, "||", result_expr, right, {})
+                ann: Ann = {"provenance": "isinstance_tuple"} if len(tnames) > 1 else {}
+                result_expr = TBinaryOp(pos, "||", result_expr, right, ann)
                 ti += 1
             return result_expr
     if fname == "any" or fname == "all":

--- a/tongues/tests/backend/codegen/base/provenance.tests
+++ b/tongues/tests/backend/codegen/base/provenance.tests
@@ -232,3 +232,11 @@ fn f(s: string, p: string) -> string {
 fn Main() -> void {
     WritelnOut(f("hello", "lo"))
 }
+
+=== isinstance with tuple of types (raised)
+fn f(v: A | B | C) -> bool {
+    return @["provenance" = "isinstance_tuple"] (IsType(v, "A") || IsType(v, "B"))
+}
+fn Main() -> void {
+    WritelnOut(ToString(f(A(0))))
+}

--- a/tongues/tests/backend/codegen/perl/provenance.tests
+++ b/tongues/tests/backend/codegen/perl/provenance.tests
@@ -105,3 +105,6 @@ return ((($s =~ /^\Q${\ $p}\E/) ? 1 : 0) ? substr($s, length($p), (length($s)) -
 
 === string removesuffix (raised)
 return ((($s =~ /\Q${\ $p}\E$/) ? 1 : 0) ? substr($s, 0, (length($s) - length($p)) - (0)) : $s);
+
+=== isinstance with tuple of types (raised)
+return eval { $v->isa('A') } || eval { $v->isa('B') };

--- a/tongues/tests/backend/codegen/python/provenance.tests
+++ b/tongues/tests/backend/codegen/python/provenance.tests
@@ -81,3 +81,6 @@ return s.removeprefix(p)
 
 === string removesuffix (raised)
 return s.removesuffix(p)
+
+=== isinstance with tuple of types (raised)
+return isinstance(v, (A, B))

--- a/tongues/tests/backend/codegen/ruby/provenance.tests
+++ b/tongues/tests/backend/codegen/ruby/provenance.tests
@@ -81,3 +81,6 @@ return s.delete_prefix(p)
 
 === string removesuffix (raised)
 return s.delete_suffix(p)
+
+=== isinstance with tuple of types (raised)
+return v.is_a?(A) || v.is_a?(B)

--- a/tongues/tests/backend/emit/base/isinstance.tests
+++ b/tongues/tests/backend/emit/base/isinstance.tests
@@ -11,3 +11,20 @@ def main() -> None:
         print("yes")
 if __name__ == "__main__":
     main()
+
+=== isinstance with tuple of types
+import sys
+class Animal:
+    name: str
+class Dog(Animal):
+    breed: str
+class Cat(Animal):
+    color: str
+def check(a: Animal) -> bool:
+    return isinstance(a, (Dog, Cat))
+def main() -> None:
+    d: Dog = Dog(name="Rex", breed="Lab")
+    if check(d):
+        print("yes")
+if __name__ == "__main__":
+    main()

--- a/tongues/tests/backend/emit/perl/isinstance.tests
+++ b/tongues/tests/backend/emit/perl/isinstance.tests
@@ -1,2 +1,5 @@
 === isinstance check
 eval { $a->isa('Dog') }
+
+=== isinstance with tuple of types
+eval { $a->isa('Dog') } || eval { $a->isa('Cat') }

--- a/tongues/tests/backend/emit/python/isinstance.tests
+++ b/tongues/tests/backend/emit/python/isinstance.tests
@@ -1,2 +1,5 @@
 === isinstance check
 isinstance(a, Dog)
+
+=== isinstance with tuple of types
+isinstance(a, (Dog, Cat))

--- a/tongues/tests/backend/emit/ruby/isinstance.tests
+++ b/tongues/tests/backend/emit/ruby/isinstance.tests
@@ -1,2 +1,5 @@
 === isinstance check
 a.is_a?(Dog)
+
+=== isinstance with tuple of types
+a.is_a?(Dog) || a.is_a?(Cat)

--- a/tongues/tests/frontend/lowering/builtins.tests
+++ b/tongues/tests/frontend/lowering/builtins.tests
@@ -128,6 +128,23 @@ def f(n: Node) -> bool:
 Leaf
 ---
 
+=== isinstance with tuple of types
+from dataclasses import dataclass
+@dataclass
+class A:
+    x: int
+@dataclass
+class B:
+    y: str
+@dataclass
+class C:
+    z: float
+def f(v: A | B | C) -> bool:
+    return isinstance(v, (A, B))
+---
+IsType(v, "A") || IsType(v, "B")
+---
+
 === sum of list
 def f(xs: list[int]) -> int:
     return sum(xs)

--- a/tongues/tests/frontend/subset/builtins.tests
+++ b/tongues/tests/frontend/subset/builtins.tests
@@ -152,6 +152,13 @@ def f(x: object) -> bool:
 ok
 ---
 
+=== isinstance with tuple of types allowed
+def f(x: object) -> bool:
+    return isinstance(x, (int, str))
+---
+ok
+---
+
 === range in for loop allowed
 def f() -> int:
     total: int = 0


### PR DESCRIPTION
Closes #56

## Summary
- Lower `isinstance(x, (A, B, C))` into an or-chain of `IsType` checks with `isinstance_tuple` provenance
- Python backend reconstructs the idiomatic `isinstance(x, (A, B, C))` tuple form from provenance
- Ruby and Perl emit the or-chain natively (`is_a?` / `isa` calls joined with `||`)