### PR TITLE
Support `type` aliases, replace implicit PascalCase heuristic

### DIFF
--- a/tongues/src/frontend/bind.py
+++ b/tongues/src/frontend/bind.py
@@ -182,7 +182,6 @@ BANNED_NODES: set[str] = {
     "Lambda",
     "Global",
     "Nonlocal",
-    "TypeAlias",
     "TryStar",
 }
 
@@ -421,6 +420,8 @@ class Verifier:
             self.visit_YieldFrom(node)
         elif node_type == "With":
             self.visit_With(node)
+        elif node_type == "TypeAlias":
+            self.visit_TypeAlias(node)
         elif node_type == "Match":
             pass
         else:
@@ -524,6 +525,7 @@ class Verifier:
             "Load",
             "Store",
             "Del",
+            "TypeAlias",
         }
         return node_type in known
 
@@ -889,6 +891,18 @@ class Verifier:
         # Visit children
         for tgt in targets:
             self.visit(tgt)
+        self.visit(value)
+
+    def visit_TypeAlias(self, node: ASTNode) -> None:
+        """Check type alias constraints."""
+        if self.in_function:
+            self.error(node, "syntax", "type alias must be at module level")
+            return
+        type_params = get_nodes(node, "type_params")
+        if type_params:
+            self.error(node, "syntax", "generic type aliases not supported")
+            return
+        value = get_node(node, "value")
         self.visit(value)
 
     def visit_AnnAssign(self, node: ASTNode) -> None:
@@ -1651,20 +1665,6 @@ def is_all_caps(name: str) -> bool:
     return has_letter
 
 
-def is_type_alias(name: str, value: ASTNode) -> bool:
-    """Check if this looks like a type alias (PascalCase = type expression)."""
-    if not name:
-        return False
-    # Must start with uppercase
-    if not name[0].isupper():
-        return False
-    # Value should be a Subscript (like dict[str, object]) or Name (like int)
-    value_type = get_str(value, "_type")
-    if value_type == "Subscript" or value_type == "Name" or value_type == "BinOp":
-        return True
-    return False
-
-
 class NameResolver:
     """Resolves names in a dict-based AST."""
 
@@ -1760,11 +1760,12 @@ class NameResolver:
                                 name, "constant", "module", lineno, col, "", ""
                             )
                             self._register_module_name(stmt, info)
-                        elif is_type_alias(name, value):
-                            info = NameInfo(
-                                name, "type_alias", "module", lineno, col, "", ""
-                            )
-                            self._register_module_name(stmt, info)
+            elif node_type == "TypeAlias":
+                name_node = get_node(stmt, "name")
+                name = get_str(name_node, "id")
+                if name:
+                    info = NameInfo(name, "type_alias", "module", lineno, col, "", "")
+                    self._register_module_name(stmt, info)
             elif node_type == "AnnAssign":
                 target = get_node(stmt, "target")
                 if get_str(target, "_type") == "Name":
@@ -2348,22 +2349,17 @@ def _compute_derived(
             result.class_bases[mname] = list(info.bases)
     ta_body = get_nodes(ast_dict, "body")
     for ta_stmt in ta_body:
-        if get_str(ta_stmt, "_type") == "Assign":
-            ta_targets = get_nodes(ta_stmt, "targets")
-            if len(ta_targets) == 1:
-                ta_target = ta_targets[0]
-                if get_str(ta_target, "_type") == "Name":
-                    ta_name = get_str(ta_target, "id")
-                    if ta_name:
-                        ta_info = table.module_names.get(ta_name)
-                        if ta_info is not None and ta_info.kind == "type_alias":
-                            ta_value_v = ta_stmt.get("value")
-                            ta_value: ASTNode | None = None
-                            if isinstance(ta_value_v, JDict):
-                                ta_value = ta_value_v.entries
-                            ta_str = annotation_to_str(ta_value)
-                            if ta_str:
-                                result.type_aliases[ta_name] = ta_str
+        if get_str(ta_stmt, "_type") == "TypeAlias":
+            ta_name_node = get_node(ta_stmt, "name")
+            ta_name = get_str(ta_name_node, "id")
+            if ta_name:
+                ta_value_v = ta_stmt.get("value")
+                ta_value: ASTNode | None = None
+                if isinstance(ta_value_v, JDict):
+                    ta_value = ta_value_v.entries
+                ta_str = annotation_to_str(ta_value)
+                if ta_str:
+                    result.type_aliases[ta_name] = ta_str
     csf_body = get_nodes(ast_dict, "body")
     for csf_node in csf_body:
         if get_str(csf_node, "_type") == "ClassDef":

--- a/tongues/src/frontend/types.py
+++ b/tongues/src/frontend/types.py
@@ -228,7 +228,7 @@ class JDict(JsonValue):
 
 
 # Type alias for AST dict nodes
-ASTNode = dict[str, JsonValue]
+type ASTNode = dict[str, JsonValue]
 
 
 # ============================================================

--- a/tongues/src/taytsh/ast.py
+++ b/tongues/src/taytsh/ast.py
@@ -11,7 +11,7 @@ from ..frontend.types import JsonValue, JStr, JInt, JFloat, JBool, JNull, JList,
 # Annotation type alias (not a runtime construct, just for brevity)
 # ============================================================
 
-Ann = dict[str, str]
+type Ann = dict[str, str]
 
 
 # ============================================================

--- a/tongues/src/tongues.py
+++ b/tongues/src/tongues.py
@@ -542,6 +542,11 @@ def _collect_module_names(
                     if tid != "":
                         result.append((tid, lineno, col, stmt))
                 j += 1
+        elif node_type == "TypeAlias":
+            name_node = get_node(stmt, "name")
+            tid = get_str(name_node, "id")
+            if tid != "":
+                result.append((tid, lineno, col, stmt))
         elif node_type == "AnnAssign":
             tgt = get_node(stmt, "target")
             if get_str(tgt, "_type") == "Name":
@@ -1308,6 +1313,9 @@ def merge_project(
             def_name = ""
             if stype == "ClassDef" or stype == "FunctionDef":
                 def_name = get_str(bstmt, "name")
+            elif stype == "TypeAlias":
+                ta_name_node = get_node(bstmt, "name")
+                def_name = get_str(ta_name_node, "id")
             elif stype == "Assign":
                 targets = get_nodes(bstmt, "targets")
                 if len(targets) > 0:

--- a/tongues/tests/frontend/linker/merge.tests
+++ b/tongues/tests/frontend/linker/merge.tests
@@ -124,7 +124,7 @@ stdout-contains: use_b
 
 === dedup keeps one copy
 file: a.py
-ASTNode = dict[str, object]
+type ASTNode = dict[str, object]
 
 def make_a() -> ASTNode:
     x: ASTNode = {}
@@ -132,7 +132,7 @@ def make_a() -> ASTNode:
 file: b.py
 from .a import make_a
 
-ASTNode = dict[str, object]
+type ASTNode = dict[str, object]
 
 def make_b() -> ASTNode:
     x: ASTNode = make_a()

--- a/tongues/tests/frontend/lowering/type_aliases.tests
+++ b/tongues/tests/frontend/lowering/type_aliases.tests
@@ -1,0 +1,9 @@
+=== type alias is transparent in lowering
+type Items = list[int]
+def f(x: Items) -> Items:
+    return x
+---
+fn f(x: list[int]) -> list[int] {
+    return x
+}
+---

--- a/tongues/tests/frontend/merge/fixtures/dedup/a.py
+++ b/tongues/tests/frontend/merge/fixtures/dedup/a.py
@@ -1,4 +1,4 @@
-ASTNode = dict[str, object]
+type ASTNode = dict[str, object]
 
 
 def make_a() -> ASTNode:

--- a/tongues/tests/frontend/merge/fixtures/dedup/b.py
+++ b/tongues/tests/frontend/merge/fixtures/dedup/b.py
@@ -1,6 +1,6 @@
 from .a import make_a
 
-ASTNode = dict[str, object]
+type ASTNode = dict[str, object]
 
 
 def make_b() -> ASTNode:

--- a/tongues/tests/frontend/pycheck/type_aliases.tests
+++ b/tongues/tests/frontend/pycheck/type_aliases.tests
@@ -1,0 +1,31 @@
+=== alias in parameter and return position
+type Items = list[int]
+def f(x: Items) -> Items:
+    return x
+---
+ok
+---
+
+=== alias for tuple
+type Pair = tuple[str, int]
+def f() -> Pair:
+    return ("hi", 1)
+---
+ok
+---
+
+=== alias for union
+type Result = int | str
+def f(x: Result) -> Result:
+    return x
+---
+ok
+---
+
+=== alias type mismatch caught
+type Items = list[int]
+def f(x: str) -> Items:
+    return x
+---
+error: type
+---

--- a/tongues/tests/frontend/subset/type_aliases.tests
+++ b/tongues/tests/frontend/subset/type_aliases.tests
@@ -1,0 +1,46 @@
+=== type alias with list
+type Items = list[int]
+def f(x: Items) -> Items:
+    return x
+---
+ok
+---
+
+=== type alias with tuple
+type Pair = tuple[str, int]
+def f() -> Pair:
+    return ("hi", 1)
+---
+ok
+---
+
+=== type alias with union
+type Result = int | str
+def f(x: Result) -> Result:
+    return x
+---
+ok
+---
+
+=== type alias simple name
+type Name = str
+def f(x: Name) -> Name:
+    return x
+---
+ok
+---
+
+=== generic type alias rejected
+type Items[T] = list[T]
+def f() -> None:
+    pass
+---
+error: generic type alias
+---
+
+=== type alias inside function rejected
+def f() -> None:
+    type X = int
+---
+error: module level
+---


### PR DESCRIPTION
Closes #66

## Summary
- Adds support for explicit `type X = ...` statements (Python 3.12 type alias syntax)
- Removes the fragile implicit alias detection that relied on PascalCase naming + type-expression heuristics
- Generic type params (`type X[T] = ...`) are rejected for now
- Handles TypeAlias nodes in the merge/linker pipeline (name collection, dedup, renaming)
- Converts existing implicit aliases in source code and test fixtures to `type` syntax