### PR TITLE
Use tuple unpacking in lib modules

### DIFF
--- a/tongues/src/lib/csv.py
+++ b/tongues/src/lib/csv.py
@@ -42,10 +42,8 @@ def _parse(text: str, sep: str) -> list[list[str]]:
                 pos += 1
             line += 1
             continue
-        result: tuple[list[str], int, int] = _parse_record(text, pos, line, sep)
-        records.append(result[0])
-        pos = result[1]
-        line = result[2]
+        record, pos, line = _parse_record(text, pos, line, sep)
+        records.append(record)
     return records
 
 
@@ -56,10 +54,8 @@ def _parse_record(
     n: int = len(text)
     fields: list[str] = []
     while True:
-        result: tuple[str, int, int] = _parse_field(text, pos, line, sep)
-        fields.append(result[0])
-        pos = result[1]
-        line = result[2]
+        field, pos, line = _parse_field(text, pos, line, sep)
+        fields.append(field)
         if pos >= n:
             break
         if text[pos] == sep:

--- a/tongues/src/lib/glob.py
+++ b/tongues/src/lib/glob.py
@@ -80,7 +80,7 @@ def _match_chunk(
     """Match pattern[ps:pe] against text at tp. Returns (ok, next_tp)."""
     tn: int = len(text)
     ch: str = ""
-    result: tuple[bool, int] = (False, 0)
+    ok: bool = False
     while ps < pe:
         if tp >= tn:
             return (False, tp)
@@ -90,10 +90,9 @@ def _match_chunk(
             tp += 1
         elif ch == "[":
             ps += 1
-            result = _match_class(pattern, ps, text[tp])
-            if not result[0]:
+            ok, ps = _match_class(pattern, ps, text[tp])
+            if not ok:
                 return (False, tp)
-            ps = result[1]
             tp += 1
         elif ch == "\\":
             ps += 1
@@ -117,32 +116,29 @@ def glob_match(pattern: str, text: str) -> bool:
     tp: int = 0
     pn: int = len(pattern)
     tn: int = len(text)
-    scan: tuple[bool, int, int] = (False, 0, 0)
     star: bool = False
     cs: int = 0
     ce: int = 0
-    result: tuple[bool, int] = (False, 0)
+    ok: bool = False
+    next_tp: int = 0
     found: bool = False
     i: int = 0
     while pp < pn:
-        scan = _scan_chunk(pattern, pp)
-        star = scan[0]
-        cs = scan[1]
-        ce = scan[2]
+        star, cs, ce = _scan_chunk(pattern, pp)
         if star and cs == ce:
             return True
-        result = _match_chunk(pattern, cs, ce, text, tp)
-        if result[0] and (result[1] == tn or ce < pn):
-            tp = result[1]
+        ok, next_tp = _match_chunk(pattern, cs, ce, text, tp)
+        if ok and (next_tp == tn or ce < pn):
+            tp = next_tp
             pp = ce
             continue
         if star:
             found = False
             i = tp + 1
             while i <= tn:
-                result = _match_chunk(pattern, cs, ce, text, i)
-                if result[0] and (result[1] == tn or ce < pn):
-                    tp = result[1]
+                ok, next_tp = _match_chunk(pattern, cs, ce, text, i)
+                if ok and (next_tp == tn or ce < pn):
+                    tp = next_tp
                     pp = ce
                     found = True
                     break

--- a/tongues/src/lib/percent_encode.py
+++ b/tongues/src/lib/percent_encode.py
@@ -113,9 +113,8 @@ def percent_decode(s: str) -> str:
     data: bytes = bytes(raw)
     out: list[str] = []
     j: int = 0
-    result: tuple[int, int] = (0, 0)
+    cp: int = 0
     while j < len(data):
-        result = _decode_cp(data, j)
-        out.append(chr(result[0]))
-        j = result[1]
+        cp, j = _decode_cp(data, j)
+        out.append(chr(cp))
     return "".join(out)

--- a/tongues/src/lib/utf8.py
+++ b/tongues/src/lib/utf8.py
@@ -121,9 +121,8 @@ def utf8_decode(data: bytes) -> list[int]:
     out: list[int] = []
     pos: int = 0
     while pos < len(data):
-        result: tuple[int, int] = utf8_decode_codepoint(data, pos)
-        out.append(result[0])
-        pos = result[1]
+        cp, pos = utf8_decode_codepoint(data, pos)
+        out.append(cp)
     return out
 
 
@@ -132,8 +131,7 @@ def utf8_is_valid(data: bytes) -> bool:
     pos: int = 0
     while pos < len(data):
         try:
-            result: tuple[int, int] = utf8_decode_codepoint(data, pos)
-            pos = result[1]
+            _, pos = utf8_decode_codepoint(data, pos)
         except Utf8Error:
             return False
     return True
@@ -144,7 +142,6 @@ def utf8_codepoint_len(data: bytes) -> int:
     count: int = 0
     pos: int = 0
     while pos < len(data):
-        result: tuple[int, int] = utf8_decode_codepoint(data, pos)
-        pos = result[1]
+        _, pos = utf8_decode_codepoint(data, pos)
         count += 1
     return count


### PR DESCRIPTION
## Summary
- Replace verbose `result[0]`/`result[1]` index patterns with tuple unpacking across utf8, csv, glob, and percent_encode stdlib modules
- Proves tuple unpacking works end-to-end through all backends (Perl, Python, Ruby)
- Net reduction: 23 additions, 35 deletions

Closes #173