### PR TITLE
Support recursive type aliases, use JsonValue in json.py

### DIFF
--- a/tongues/src/frontend/typecollect.py
+++ b/tongues/src/frontend/typecollect.py
@@ -341,6 +341,7 @@ def _split_union_members(s: str) -> list[str]:
 
 # Type alias expansions, populated by collect_signatures()
 _TYPE_ALIASES: dict[str, str] = {}
+_EXPANDING_ALIASES: dict[str, bool] = {}
 
 # Class base mappings, populated by collect_signatures()
 _CLASS_BASES: dict[str, list[str]] = {}
@@ -384,11 +385,19 @@ def py_type_to_type_dict(
     s = py_type.strip()
     if not s:
         return InterfaceRef("any")
-    # Expand type aliases
+    # Expand type aliases (with recursion guard)
     if s in _TYPE_ALIASES:
-        return py_type_to_type_dict(
+        if s in _EXPANDING_ALIASES:
+            errors.append(
+                TypeCollectError(lineno, col, "recursive type alias '" + s + "'")
+            )
+            return InterfaceRef("any")
+        _EXPANDING_ALIASES[s] = True
+        result = py_type_to_type_dict(
             _TYPE_ALIASES[s], known_classes, errors, lineno, col
         )
+        _EXPANDING_ALIASES.pop(s)
+        return result
     # Check for union (A | B) — only if the split produces multiple top-level members
     if " | " in s:
         members = _split_union_members(s)
@@ -941,6 +950,8 @@ def collect_signatures(
     """Collect function and method signatures from the module AST."""
     while _TYPE_ALIASES:
         _TYPE_ALIASES.pop(list(_TYPE_ALIASES.keys())[0])
+    while _EXPANDING_ALIASES:
+        _EXPANDING_ALIASES.pop(list(_EXPANDING_ALIASES.keys())[0])
     while _CLASS_BASES:
         _CLASS_BASES.pop(list(_CLASS_BASES.keys())[0])
     if class_bases is not None:

--- a/tongues/src/lib/json.py
+++ b/tongues/src/lib/json.py
@@ -11,6 +11,7 @@ class JsonError(Exception):
 
 _HEX: str = "0123456789abcdef"
 
+type JsonValue = JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject
 
 # -- JSON value types (discriminated union via isinstance) --
 
@@ -37,16 +38,12 @@ class JsonString:
 
 @dataclass
 class JsonArray:
-    items: list[JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject]
+    items: list[JsonValue]
 
 
 @dataclass
 class JsonObject:
-    entries: list[
-        tuple[
-            str, JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject
-        ]
-    ]
+    entries: list[tuple[str, JsonValue]]
 
 
 # -- Parser state --
@@ -54,7 +51,7 @@ class JsonObject:
 
 @dataclass
 class ParseResult:
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject
+    value: JsonValue
     pos: int
 
 
@@ -234,9 +231,7 @@ def _parse_string_raw(s: str, pos: int) -> tuple[str, int]:
 def _parse_array(s: str, pos: int) -> ParseResult:
     pos = _expect(s, pos, "[")
     pos = _skip_ws(s, pos)
-    items: list[
-        JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject
-    ] = []
+    items: list[JsonValue] = []
     if pos < len(s) and s[pos] == "]":
         return ParseResult(JsonArray(items), pos + 1)
     result: ParseResult = _parse_value(s, pos)
@@ -254,11 +249,7 @@ def _parse_array(s: str, pos: int) -> ParseResult:
 def _parse_object(s: str, pos: int) -> ParseResult:
     pos = _expect(s, pos, "{")
     pos = _skip_ws(s, pos)
-    entries: list[
-        tuple[
-            str, JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject
-        ]
-    ] = []
+    entries: list[tuple[str, JsonValue]] = []
     if pos < len(s) and s[pos] == "}":
         return ParseResult(JsonObject(entries), pos + 1)
     key, pos = _parse_string_raw(s, _skip_ws(s, pos))
@@ -307,8 +298,8 @@ def _parse_value(s: str, pos: int) -> ParseResult:
 
 def json_parse(
     s: str,
-) -> JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject:
-    """Parse a JSON string into a JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject."""
+) -> JsonValue:
+    """Parse a JSON string into a JsonValue."""
     result: ParseResult = _parse_value(s, 0)
     pos: int = _skip_ws(s, result.pos)
     if pos < len(s):
@@ -320,9 +311,9 @@ def json_parse(
 
 
 def json_stringify(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
 ) -> str:
-    """Serialize a JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject to a JSON string."""
+    """Serialize a JsonValue to a JSON string."""
     if isinstance(value, JsonNull):
         return "null"
     elif isinstance(value, JsonBool):
@@ -385,7 +376,7 @@ def _escape_string(s: str) -> str:
 
 
 def json_get_string(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
 ) -> str:
     if isinstance(value, JsonString):
         return value.value
@@ -393,7 +384,7 @@ def json_get_string(
 
 
 def json_get_number(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
 ) -> float:
     if isinstance(value, JsonNumber):
         return value.value
@@ -401,7 +392,7 @@ def json_get_number(
 
 
 def json_get_bool(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
 ) -> bool:
     if isinstance(value, JsonBool):
         return value.value
@@ -409,17 +400,17 @@ def json_get_bool(
 
 
 def json_get_items(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
-) -> list[JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject]:
+    value: JsonValue,
+) -> list[JsonValue]:
     if isinstance(value, JsonArray):
         return value.items
     raise JsonError("expected JsonArray")
 
 
 def json_get_field(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
     key: str,
-) -> JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject:
+) -> JsonValue:
     if isinstance(value, JsonObject):
         for k, v in value.entries:
             if k == key:
@@ -429,6 +420,6 @@ def json_get_field(
 
 
 def json_is_null(
-    value: JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject,
+    value: JsonValue,
 ) -> bool:
     return isinstance(value, JsonNull)


### PR DESCRIPTION
## Summary
- Add recursion guard (`_EXPANDING_ALIASES`) to `py_type_to_type_dict` so type aliases referencing structs whose fields use the same alias don't infinite-loop
- Replace 18 inline `JsonNull | JsonBool | JsonNumber | JsonString | JsonArray | JsonObject` unions in `lib/json.py` with a single `type JsonValue` alias

Closes #186