### PR TITLE
Run pyright on self-transpiled Python output

### DIFF
--- a/justfile
+++ b/justfile
@@ -150,6 +150,7 @@ lang-python *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     just _self-transpile python
+    uvx pyright tongues/.out/tongues.py
     uv run --directory tongues pytest tests/test_frontend.py tests/test_middleend.py \
         tests/test_backend_codegen.py tests/test_backend_target.py tests/test_taytsh_app.py \
         tests/test_frontend_linker.py \


### PR DESCRIPTION
## Summary
- Add `uvx pyright` check to `lang-python` target, running after self-transpilation and before the test suite