### PR TITLE
Validate constructor argument types against __init__ parameters

### DIFF
--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -2685,6 +2685,11 @@ def _validate_call_args(
             _check_call_args(func_info, args, env, ctx, lineno, n_kw)
             return
         if fname in ctx.known_classes:
+            methods = ctx.tc_result.methods.get(fname)
+            if methods is not None:
+                init_method = methods.get("__init__")
+                if init_method is not None:
+                    _check_call_args(init_method, args, env, ctx, lineno, n_kw)
             return
         ftype = env.get_type(fname)
         if ftype is not None and isinstance(ftype, FuncType):

--- a/tongues/tests/frontend/pycheck/hierarchy.tests
+++ b/tongues/tests/frontend/pycheck/hierarchy.tests
@@ -281,3 +281,36 @@ def f(n: Node) -> list[str]:
 ---
 ok
 ---
+
+=== constructor rejects base type where subclass expected
+class Node:
+    pass
+class ArithNode(Node):
+    pass
+class ArithBinaryOp(ArithNode):
+    def __init__(self, left: ArithNode, right: ArithNode) -> None:
+        self.left: ArithNode = left
+        self.right: ArithNode = right
+def parse_expr() -> Node:
+    return ArithNode()
+def f() -> ArithBinaryOp:
+    left: Node = parse_expr()
+    right: Node = parse_expr()
+    return ArithBinaryOp(left, right)
+---
+error: argument 1 has type Node, expected ArithNode
+---
+
+=== constructor accepts subclass where base expected
+class Node:
+    pass
+class Expr(Node):
+    pass
+class Wrapper:
+    def __init__(self, child: Node) -> None:
+        self.child: Node = child
+def f() -> Wrapper:
+    return Wrapper(Expr())
+---
+ok
+---


### PR DESCRIPTION
## Summary
- pycheck skipped argument type validation for class constructor calls — `_validate_call` returned early when the target was a known class without checking args against `__init__` parameters
- Now looks up the class's `__init__` method and runs `_check_call_args`, catching cases like passing a `Node` where an `ArithNode` is expected

Closes #245