### PR TITLE
Handle Attribute targets in tuple unpacking during lowering

### DIFF
--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -4924,6 +4924,11 @@ def _lower_tuple_assign(
                     elif name in env.hoisted_stmts:
                         _backpatch_hoisted(pos, name, PrimitiveType(result_kind), env)
                     targets.append(TVar(pos, ann, safe))
+                elif _is_ast(e, "Attribute"):
+                    attr = get_str(e, "attr")
+                    obj_node = get_node(e, "value")
+                    obj = _lower_expr(obj_node, env, ctx)
+                    targets.append(TFieldAccess(pos, {}, obj, attr))
             stmts.append(TTupleAssignStmt(pos, {}, targets, value))
             return stmts
     value = _lower_expr(value_node, env, ctx)
@@ -4950,6 +4955,11 @@ def _lower_tuple_assign(
                 et = elem_types[i] if i < len(elem_types) else INT_TYPE
                 _backpatch_hoisted(pos, name, et, env)
             targets.append(TVar(pos, ann, safe))
+        elif _is_ast(e, "Attribute"):
+            attr = get_str(e, "attr")
+            obj_node = get_node(e, "value")
+            obj = _lower_expr(obj_node, env, ctx)
+            targets.append(TFieldAccess(pos, {}, obj, attr))
     stmts.append(TTupleAssignStmt(pos, {}, targets, value))
     return stmts
 

--- a/tongues/tests/frontend/lowering/statements.tests
+++ b/tongues/tests/frontend/lowering/statements.tests
@@ -269,6 +269,18 @@ def f() -> int:
 a, b = DivMod(10, 3)
 ---
 
+=== tuple unpack from list pop into self attributes
+class State:
+    def __init__(self) -> None:
+        self.x: int = 0
+        self.y: str = ""
+        self._stack: list[tuple[int, str]] = []
+    def pop(self) -> None:
+        self.x, self.y = self._stack.pop()
+---
+this.x, this.y = Pop(this._stack)
+---
+
 === optional annotated declaration
 def f() -> None:
     x: str | None = None


### PR DESCRIPTION
Closes #288

## Summary
- `_lower_tuple_assign` only handled `Name` targets in the tuple unpack loop, so `self.x, self.y = self._stack.pop()` silently dropped the targets, producing ` = Pop(this._stack)` instead of `this.x, this.y = Pop(this._stack)`
- Add `Attribute` branch to both the divmod special-case and general tuple unpack paths in lowering
- Add regression test in lowering/statements.tests