### PR TITLE
Fix release workflow: create .out directory before transpiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Transpile all targets
         run: |
           cd tongues && uv sync
+          mkdir -p .out
           for target in python ruby perl javascript java; do
             ext=$(echo "$target" | sed 's/python/py/;s/ruby/rb/;s/perl/pl/;s/javascript/js/;s/java/java/')
             uv run bin/tongues --target "$target" -o ".out/tongues.$ext" src


### PR DESCRIPTION
## Summary
- The transpile step in the release workflow failed because `.out/` didn't exist
- Adds `mkdir -p .out` before the transpile loop, matching what the justfile does