### PR TITLE
Add known-failures mechanism for app tests

### DIFF
--- a/tongues/tests/backend/app/known-failures.txt
+++ b/tongues/tests/backend/app/known-failures.txt
@@ -1,0 +1,3 @@
+# Known-failing apptest/target combos: <apptest stem> <target> <issue> [nonstrict]
+# pytest marks these xfail (strict unless 'nonstrict'); the test-transpiled runners skip them.
+# Remove a line when its issue is fixed — a strict xfail that passes fails the suite.

--- a/tongues/tests/harness.py
+++ b/tongues/tests/harness.py
@@ -1355,6 +1355,21 @@ def discover_app_tests(
     return results
 
 
+def load_known_failures(test_dir: Path) -> dict[tuple[str, str], tuple[str, bool]]:
+    """Map (apptest stem, target) -> (issue ref, strict) from known-failures.txt."""
+    path = test_dir / "known-failures.txt"
+    result: dict[tuple[str, str], tuple[str, bool]] = {}
+    if not path.exists():
+        return result
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        tokens = line.split()
+        result[(tokens[0], tokens[1])] = (tokens[2], "nonstrict" not in tokens[3:])
+    return result
+
+
 def _cli_needs_backend(spec: dict) -> bool:
     """True if the test will reach the backend (no --stop-at, expects exit 0)."""
     args = spec["args"]

--- a/tongues/tests/test-transpiled.js
+++ b/tongues/tests/test-transpiled.js
@@ -513,9 +513,24 @@ function runtimeAvailable(lang) {
     } catch { return false; }
 }
 
+// Set of "stem|target" combos expected to fail (see known-failures.txt)
+function loadKnownFailures(testDir) {
+    const path = nodePath.join(testDir, "known-failures.txt");
+    const known = new Set();
+    if (!nodeFs.existsSync(path)) return known;
+    for (const raw of nodeFs.readFileSync(path, "utf-8").split("\n")) {
+        const line = raw.trim();
+        if (!line || line.startsWith("#")) continue;
+        const tokens = line.split(/\s+/);
+        known.add(`${tokens[0]}|${tokens[1]}`);
+    }
+    return known;
+}
+
 function runAppTests(testDir) {
     const results = [];
     const available = Object.keys(RUNTIMES).filter(runtimeAvailable).sort();
+    const knownFailures = loadKnownFailures(testDir);
     for (const testFile of globFiles(testDir, "apptest_*.py").concat(globFiles(testDir, "apptest_*.py")).filter((v, i, a) => a.indexOf(v) === i)) {
         // Re-glob properly
     }
@@ -544,6 +559,10 @@ function runAppTests(testDir) {
         }
         for (const target of available) {
             const testId = `${stem}[${target}]`;
+            if (knownFailures.has(`${stem}|${target}`)) {
+                results.push(["skip", testId, null]);
+                continue;
+            }
             let result;
             if (libNames.length === 0) {
                 const tmpFile = nodePath.join(os.tmpdir(), `test_${Date.now()}_${Math.random().toString(36).slice(2)}.py`);
@@ -792,6 +811,7 @@ function collectTests() {
                 }
                 case "app": {
                     const available = Object.keys(RUNTIMES).filter(runtimeAvailable).sort();
+                    const knownFailures = loadKnownFailures(testDir);
                     const appFiles = nodeFs.existsSync(testDir)
                         ? nodeFs.readdirSync(testDir).filter(f => f.startsWith("apptest_") && f.endsWith(".py")).sort().map(f => nodePath.join(testDir, f))
                         : [];
@@ -821,6 +841,10 @@ function collectTests() {
                         });
                         for (const target of available) {
                             const testId = `${stem}[${target}]`;
+                            if (knownFailures.has(`${stem}|${target}`)) {
+                                collected.push([phaseName, testId, "skip", null]);
+                                continue;
+                            }
                             collected.push([phaseName, testId, "app", { source: String(source), libParts, target }]);
                         }
                     }

--- a/tongues/tests/test-transpiled.pl
+++ b/tongues/tests/test-transpiled.pl
@@ -540,8 +540,23 @@ sub run_emit_tests ($test_dir) {
     return \@results;
 }
 
+# Set of "stem|target" combos expected to fail (see known-failures.txt)
+sub load_known_failures ($test_dir) {
+    my $path = File::Spec->catfile($test_dir, "known-failures.txt");
+    my %known;
+    return \%known unless -f $path;
+    for my $raw (split /\n/, _read_file($path)) {
+        my $line = $raw =~ s/^\s+|\s+$//gr;
+        next if $line eq "" || $line =~ /^#/;
+        my @tokens = split /\s+/, $line;
+        $known{"$tokens[0]|$tokens[1]"} = 1;
+    }
+    return \%known;
+}
+
 sub run_app_tests ($test_dir) {
     my @results;
+    my $known_failures = load_known_failures($test_dir);
     my @available;
     for my $lang (keys %RUNTIMES) {
         my $cmd = $RUNTIMES{$lang}[0];
@@ -572,6 +587,10 @@ sub run_app_tests ($test_dir) {
         }
         for my $target (@available) {
             my $test_id = "$stem" . "[$target]";
+            if ($known_failures->{"$stem|$target"}) {
+                push @results, ["skip", $test_id, undef];
+                next;
+            }
             my $result;
             if (@$lib_names == 0) {
                 my ($tfh, $tmpfile) = tempfile("testXXXXXX", SUFFIX => ".py", TMPDIR => 1);
@@ -804,6 +823,7 @@ sub collect_tests {
                 }
             } elsif ($runner eq "app") {
                 my @available = grep { runtime_available($_) } sort keys %RUNTIMES;
+                my $known_failures = load_known_failures($test_dir);
                 my @app_files = sort glob("$test_dir/apptest_*.py");
                 for my $test_file (@app_files) {
                     my $stem = basename($test_file, ".py");
@@ -830,6 +850,10 @@ sub collect_tests {
                     } @lib_names;
                     for my $target (@available) {
                         my $test_id = "$stem" . "[$target]";
+                        if ($known_failures->{"$stem|$target"}) {
+                            push @collected, [$phase_name, $test_id, "skip", undef];
+                            next;
+                        }
                         push @collected, [$phase_name, $test_id, "app", { source => $source, lib_parts => \@lib_parts, target => $target }];
                     }
                 }

--- a/tongues/tests/test-transpiled.py
+++ b/tongues/tests/test-transpiled.py
@@ -719,9 +719,26 @@ def _find_lib_imports(source):
     return names
 
 
+def load_known_failures(test_dir):
+    """Set of (apptest stem, target) combos expected to fail (see known-failures.txt)."""
+    path = os.path.join(test_dir, "known-failures.txt")
+    known = set()
+    if not os.path.exists(path):
+        return known
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            tokens = line.split()
+            known.add((tokens[0], tokens[1]))
+    return known
+
+
 def run_app_tests(test_dir):
     results = []
     available = [lang for lang, cmd in RUNTIMES.items() if _runtime_available(cmd)]
+    known_failures = load_known_failures(test_dir)
     for test_file in sorted(glob.glob(os.path.join(test_dir, "apptest_*.py"))):
         stem = os.path.splitext(os.path.basename(test_file))[0]
         with open(test_file) as fh:
@@ -744,6 +761,9 @@ def run_app_tests(test_dir):
         lib_names = seen
         for target in available:
             test_id = f"{stem}[{target}]"
+            if (stem, target) in known_failures:
+                results.append(("skip", test_id, None))
+                continue
             if not lib_names:
                 fd, tmp_path = tempfile.mkstemp(suffix=".py")
                 try:
@@ -1384,6 +1404,7 @@ def _collect_tests(tests_config):
                 available = [
                     lang for lang, cmd in RUNTIMES.items() if _runtime_available(cmd)
                 ]
+                known_failures = load_known_failures(test_dir)
                 for test_file in sorted(
                     glob.glob(os.path.join(test_dir, "apptest_*.py"))
                 ):
@@ -1414,6 +1435,9 @@ def _collect_tests(tests_config):
                             lib_parts.append((f"lib/{name}.py", fh.read()))
                     for target in available:
                         test_id = f"{stem}[{target}]"
+                        if (stem, target) in known_failures:
+                            collected.append((phase_name, test_id, "skip", None))
+                            continue
                         collected.append(
                             (phase_name, test_id, "app", (target, source, lib_parts))
                         )

--- a/tongues/tests/test-transpiled.rb
+++ b/tongues/tests/test-transpiled.rb
@@ -419,9 +419,24 @@ def run_emit_tests(test_dir)
   results
 end
 
+# Set of "stem|target" combos expected to fail (see known-failures.txt)
+def load_known_failures(test_dir)
+  path = File.join(test_dir, "known-failures.txt")
+  known = Set.new
+  return known unless File.exist?(path)
+  File.read(path).each_line do |raw|
+    line = raw.strip
+    next if line.empty? || line.start_with?("#")
+    tokens = line.split
+    known << "#{tokens[0]}|#{tokens[1]}"
+  end
+  known
+end
+
 def run_app_tests(test_dir)
   results = []
   available = RUNTIMES.select { |_, cmd| system("which", cmd[0], out: File::NULL, err: File::NULL) }.keys
+  known_failures = load_known_failures(test_dir)
   Dir.glob(File.join(test_dir, "apptest_*.py")).sort.each do |test_file|
     stem = File.basename(test_file, ".py")
     source = File.read(test_file)
@@ -443,6 +458,10 @@ def run_app_tests(test_dir)
     lib_names = seen
     available.each do |target|
       test_id = "#{stem}[#{target}]"
+      if known_failures.include?("#{stem}|#{target}")
+        results << [:skip, test_id, nil]
+        next
+      end
       if lib_names.empty?
         tmp = Tempfile.new(["test", ".py"])
         begin
@@ -655,6 +674,7 @@ def collect_tests
         end
       when :app
         available = RUNTIMES.select { |_, cmd| system("which", cmd[0], out: File::NULL, err: File::NULL) }.keys
+        known_failures = load_known_failures(test_dir)
         Dir.glob(File.join(test_dir, "apptest_*.py")).sort.each do |test_file|
           stem = File.basename(test_file, ".py")
           source = File.read(test_file)
@@ -679,6 +699,10 @@ def collect_tests
           end
           available.each do |target|
             test_id = "#{stem}[#{target}]"
+            if known_failures.include?("#{stem}|#{target}")
+              collected << [phase_name, test_id, :skip, nil]
+              next
+            end
             collected << [phase_name, test_id, :app, [target, source, lib_parts]]
           end
         end

--- a/tongues/tests/test_backend_target.py
+++ b/tongues/tests/test_backend_target.py
@@ -9,6 +9,7 @@ from tests.harness import (
     RUNTIMES,
     TESTS_DIR,
     discover_app_tests,
+    load_known_failures,
     transpile_app,
     transpile_code,
 )
@@ -29,7 +30,16 @@ def pytest_generate_tests(metafunc):
             target_opt = metafunc.config.getoption("--target", default=None)
             targets = target_opt if target_opt else sorted(RUNTIMES)
             tests = discover_app_tests(test_dir, targets)
-            params = [pytest.param(path, target, id=tid) for tid, path, target in tests]
+            known = load_known_failures(test_dir)
+            params = []
+            for tid, path, target in tests:
+                entry = known.get((path.stem, target))
+                marks = (
+                    [pytest.mark.xfail(strict=entry[1], reason=entry[0])]
+                    if entry is not None
+                    else []
+                )
+                params.append(pytest.param(path, target, id=tid, marks=marks))
             metafunc.parametrize("app_source,app_target", params)
         elif run == "ordering" and "ordering_source" in metafunc.fixturenames:
             target_opt = metafunc.config.getoption("--target", default=None)
@@ -43,13 +53,16 @@ def pytest_generate_tests(metafunc):
             metafunc.parametrize("ordering_source,ordering_target", params)
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(40)
 def test_app(app_source: Path, app_target: str) -> None:
     source = app_source.read_text()
     output, err = transpile_app(source, app_target)
     if err is not None:
         pytest.fail(f"Transpile error ({app_target}): {err}")
     runtime = RUNTIMES[app_target]
+    # Keep the subprocess timeout below the pytest-timeout marker so a hung
+    # program raises a catchable TimeoutExpired (xfail-able) instead of
+    # pytest-timeout killing the process.
     result = subprocess.run(
         runtime,
         input=output.encode(),


### PR DESCRIPTION
## Summary

Infrastructure half of #381, split out to keep both PRs small.

`tests/backend/app/known-failures.txt` lists apptest/target combos expected to fail, each referencing its tracking issue. Consumers:

- **pytest** (`test_backend_target.py`): listed combos become xfail — strict unless tagged `nonstrict`, so a fixed test fails the suite until its entry is removed
- **test-transpiled.{py,js,rb,pl}**: listed combos are skipped (both serial and parallel paths)

The list ships **empty** here, so this PR is a no-op behaviorally; the entries land in #381 together with the entrypoint fix that unmasks the failures.

Also moves the inner subprocess timeout in `test_app` below the pytest-timeout marker, so a hung program raises a catchable `TimeoutExpired` (xfail-able) instead of pytest-timeout killing the whole process.

Merge order: this first, then #381.