### PR TITLE
Fix six backend bugs: Python emission fidelity, exit codes, JS codepoint consistency

### DIFF
--- a/tongues/src/backend/javascript.py
+++ b/tongues/src/backend/javascript.py
@@ -558,7 +558,7 @@ class _JavaScriptEmitter(Emitter):
             self._line()
             self._line(
                 'if (typeof module !== "undefined" && '
-                "(require.main === module || require.main === undefined)) {"
+                '(require.main === module || module.id === "[stdin]")) {'
             )
             self.indent += 1
             self._line("main();")
@@ -2756,7 +2756,11 @@ class _JavaScriptEmitter(Emitter):
         if isinstance(expr, TVar):
             ann = self.var_annotations.get(expr.name, {})
             content = ann.get("strings.content", "")
-            return content == "unknown"
+            # Unproven content may hold astral codepoints: only ascii/bmp is
+            # safe for UTF-16 code-unit operations. Defaulting unannotated
+            # vars to code units while field accesses got codepoint ops mixed
+            # the two index spaces in one program (#377).
+            return content not in ("ascii", "bmp")
         if isinstance(expr, TStringLit):
             for ch in expr.value:
                 if ord(ch) > 0xFFFF:

--- a/tongues/src/backend/javascript.py
+++ b/tongues/src/backend/javascript.py
@@ -300,6 +300,139 @@ def _scan_imports(
     return needs_fs, needs_process, needs_buffer
 
 
+def _rune_scan_stmt(stmt: TStmt, indexed: set[str], assigned: set[str]) -> None:
+    """Track string vars used in index/slice position and assignment targets."""
+    match stmt:
+        case TExprStmt():
+            _rune_scan_expr(stmt.expr, indexed)
+        case TLetStmt():
+            if stmt.value is not None:
+                _rune_scan_expr(stmt.value, indexed)
+        case TAssignStmt() | TOpAssignStmt():
+            if isinstance(stmt.target, TVar):
+                assigned.add(stmt.target.name)
+            else:
+                _rune_scan_expr(stmt.target, indexed)
+            _rune_scan_expr(stmt.value, indexed)
+        case TTupleAssignStmt():
+            for tgt in stmt.targets:
+                if isinstance(tgt, TVar):
+                    assigned.add(tgt.name)
+                else:
+                    _rune_scan_expr(tgt, indexed)
+            _rune_scan_expr(stmt.value, indexed)
+        case TReturnStmt():
+            if stmt.value is not None:
+                _rune_scan_expr(stmt.value, indexed)
+        case TThrowStmt():
+            _rune_scan_expr(stmt.expr, indexed)
+        case TIfStmt():
+            _rune_scan_expr(stmt.cond, indexed)
+            for s in stmt.then_body:
+                _rune_scan_stmt(s, indexed, assigned)
+            if stmt.else_body is not None:
+                for s in stmt.else_body:
+                    _rune_scan_stmt(s, indexed, assigned)
+        case TWhileStmt():
+            _rune_scan_expr(stmt.cond, indexed)
+            for s in stmt.body:
+                _rune_scan_stmt(s, indexed, assigned)
+        case TForStmt():
+            for b in stmt.binding:
+                assigned.add(b)
+            if isinstance(stmt.iterable, TRange):
+                for a in stmt.iterable.args:
+                    _rune_scan_expr(a, indexed)
+            else:
+                _rune_scan_expr(stmt.iterable, indexed)
+            for s in stmt.body:
+                _rune_scan_stmt(s, indexed, assigned)
+        case TMatchStmt():
+            _rune_scan_expr(stmt.expr, indexed)
+            for case in stmt.cases:
+                if isinstance(case.pattern, TPatternType):
+                    assigned.add(case.pattern.name)
+                for s in case.body:
+                    _rune_scan_stmt(s, indexed, assigned)
+            if stmt.default is not None:
+                for s in stmt.default.body:
+                    _rune_scan_stmt(s, indexed, assigned)
+        case TTryStmt():
+            for s in stmt.body:
+                _rune_scan_stmt(s, indexed, assigned)
+            for catch in stmt.catches:
+                assigned.add(catch.name)
+                for s in catch.body:
+                    _rune_scan_stmt(s, indexed, assigned)
+            if stmt.finally_body is not None:
+                for s in stmt.finally_body:
+                    _rune_scan_stmt(s, indexed, assigned)
+
+
+def _rune_scan_expr(expr: TExpr, indexed: set[str]) -> None:
+    match expr:
+        case TIndex():
+            if isinstance(expr.obj, TVar):
+                indexed.add(expr.obj.name)
+            _rune_scan_expr(expr.obj, indexed)
+            _rune_scan_expr(expr.index, indexed)
+        case TSlice():
+            if isinstance(expr.obj, TVar):
+                indexed.add(expr.obj.name)
+            _rune_scan_expr(expr.obj, indexed)
+            _rune_scan_expr(expr.low, indexed)
+            _rune_scan_expr(expr.high, indexed)
+        case TCall():
+            _rune_scan_expr(expr.func, indexed)
+            for a in expr.args:
+                _rune_scan_expr(a.value, indexed)
+        case TBinaryOp():
+            _rune_scan_expr(expr.left, indexed)
+            _rune_scan_expr(expr.right, indexed)
+        case TUnaryOp():
+            _rune_scan_expr(expr.operand, indexed)
+        case TTernary():
+            _rune_scan_expr(expr.cond, indexed)
+            _rune_scan_expr(expr.then_expr, indexed)
+            _rune_scan_expr(expr.else_expr, indexed)
+        case TFieldAccess() | TTupleAccess():
+            _rune_scan_expr(expr.obj, indexed)
+        case TListLit() | TTupleLit() | TSetLit():
+            for e in expr.elements:
+                _rune_scan_expr(e, indexed)
+        case TMapLit():
+            for k, v in expr.entries:
+                _rune_scan_expr(k, indexed)
+                _rune_scan_expr(v, indexed)
+        case TFnLit():
+            local_assigned: set[str] = set()
+            for s in expr.body:
+                _rune_scan_stmt(s, indexed, local_assigned)
+
+
+def _is_ident_char(ch: str) -> bool:
+    return ch.isalnum() or ch == "_" or ch == "$"
+
+
+def _replace_ident(text: str, name: str, repl: str) -> str:
+    """Replace whole-identifier occurrences of name in emitted JS text."""
+    out = ""
+    i = 0
+    n = len(text)
+    m = len(name)
+    while i < n:
+        if text[i : i + m] == name:
+            before_ok = i == 0 or not _is_ident_char(text[i - 1])
+            after_ok = i + m >= n or not _is_ident_char(text[i + m])
+            if before_ok and after_ok:
+                out += repl
+                i += m
+                continue
+        out += text[i]
+        i += 1
+    return out
+
+
 def _check_error_ref(expr: TExpr, refs: set[str], builtin_names: set[str]) -> None:
     if isinstance(expr, TCall):
         if isinstance(expr.func, TVar) and expr.func.name in builtin_names:
@@ -442,6 +575,9 @@ class _JavaScriptEmitter(Emitter):
         self._needs_cp_index_of: bool = False
         self.fn_names: set[str] = set()
         self.var_annotations: dict[str, dict[str, str]] = {}
+        # String params hoisted to rune arrays for O(1) codepoint indexing
+        self._rune_hoisted: dict[str, str] = {}
+        self._needs_rune_cache: bool = False
 
     def _line(self, text: str = "") -> None:
         _emit_line(self.lines, self.indent, text)
@@ -552,6 +688,18 @@ class _JavaScriptEmitter(Emitter):
             self.indent += 1
             self._line("const i = s.lastIndexOf(sub);")
             self._line("return i === -1 ? -1 : [...s.slice(0, i)].length;")
+            self.indent -= 1
+            self._line("}")
+        if self._needs_rune_cache:
+            self._line()
+            self._line("// Memoized codepoint arrays for strings of unproven")
+            self._line("// content; V8 caches string hashes so hits are O(1).")
+            self._line("const _runeCache = new Map();")
+            self._line("function _runes(s) {")
+            self.indent += 1
+            self._line("let a = _runeCache.get(s);")
+            self._line("if (a === undefined) { a = [...s]; _runeCache.set(s, a); }")
+            self._line("return a;")
             self.indent -= 1
             self._line("}")
         if any(isinstance(d, TFnDecl) and d.name == "Main" for d in module.decls):
@@ -711,7 +859,13 @@ class _JavaScriptEmitter(Emitter):
         )
         self._line("function " + fname + "(" + params + ") {")
         self.indent += 1
+        old_hoisted = self._rune_hoisted
+        self._rune_hoisted = self._collect_rune_hoists(decl)
+        for pname, arr in self._rune_hoisted.items():
+            self._needs_rune_cache = True
+            self._line("const " + arr + " = _runes(" + _restore_name(pname, {}) + ");")
         self._emit_stmts(decl.body)
+        self._rune_hoisted = old_hoisted
         self.indent -= 1
         self._line("}")
         self.var_types = old_var_types
@@ -738,7 +892,13 @@ class _JavaScriptEmitter(Emitter):
         old_self = self.self_name
         if decl.params and decl.params[0].typ is None:
             self.self_name = decl.params[0].name
+        old_hoisted = self._rune_hoisted
+        self._rune_hoisted = self._collect_rune_hoists(decl)
+        for pname, arr in self._rune_hoisted.items():
+            self._needs_rune_cache = True
+            self._line("const " + arr + " = _runes(" + _restore_name(pname, {}) + ");")
         self._emit_stmts(decl.body)
+        self._rune_hoisted = old_hoisted
         self.self_name = old_self
         self.indent -= 1
         self._line("}")
@@ -2243,7 +2403,11 @@ class _JavaScriptEmitter(Emitter):
             if self.strict_math and self._is_int_expr(expr.index):
                 idx = "Number(" + idx + ")"
             if self._is_string_expr(expr.obj) and self._needs_codepoint_ops(expr.obj):
-                return "[..." + self._expr(expr.obj) + "][" + idx + "]"
+                arr = self._rune_arr(expr.obj)
+                if arr is not None:
+                    return arr + "[" + idx + "]"
+                self._needs_rune_cache = True
+                return "_runes(" + self._expr(expr.obj) + ")[" + idx + "]"
             return self._expr(expr.obj) + "[" + idx + "]"
         if isinstance(expr, TSlice):
             return self._slice(expr)
@@ -2307,9 +2471,15 @@ class _JavaScriptEmitter(Emitter):
         if prov == "open_start" and self._is_zero(expr.low):
             low = "0"
         if self._is_string_expr(expr.obj) and self._needs_codepoint_ops(expr.obj):
+            arr = self._rune_arr(expr.obj)
+            if arr is not None:
+                if high == "":
+                    return arr + ".slice(" + low + ').join("")'
+                return arr + ".slice(" + low + ", " + high + ').join("")'
+            self._needs_rune_cache = True
             if high == "":
-                return "[..." + obj + "].slice(" + low + ').join("")'
-            return "[..." + obj + "].slice(" + low + ", " + high + ').join("")'
+                return "_runes(" + obj + ").slice(" + low + ').join("")'
+            return "_runes(" + obj + ").slice(" + low + ", " + high + ').join("")'
         if high == "":
             return obj + ".slice(" + low + ")"
         return obj + ".slice(" + low + ", " + high + ")"
@@ -2752,6 +2922,33 @@ class _JavaScriptEmitter(Emitter):
         if strings_ann:
             self.var_annotations[name] = strings_ann
 
+    def _collect_rune_hoists(self, decl: TFnDecl) -> dict[str, str]:
+        """String params that are indexed/sliced with unproven content and
+        never reassigned: alias the memoized rune array once at function
+        entry so codepoint indexing skips the cache lookup per access."""
+        param_names: set[str] = set()
+        for p in decl.params:
+            if isinstance(p.typ, TPrimitive) and p.typ.kind == "string":
+                param_names.add(p.name)
+        if not param_names:
+            return {}
+        indexed: set[str] = set()
+        assigned: set[str] = set()
+        for stmt in decl.body:
+            _rune_scan_stmt(stmt, indexed, assigned)
+        hoists: dict[str, str] = {}
+        for name in sorted(param_names & (indexed - assigned)):
+            ann = self.var_annotations.get(name, {})
+            if ann.get("strings.content", "") in ("ascii", "bmp"):
+                continue
+            hoists[name] = _restore_name(name, {}) + "__runes"
+        return hoists
+
+    def _rune_arr(self, expr: TExpr) -> str | None:
+        if isinstance(expr, TVar):
+            return self._rune_hoisted.get(expr.name)
+        return None
+
     def _needs_codepoint_ops(self, expr: TExpr) -> bool:
         if isinstance(expr, TVar):
             ann = self.var_annotations.get(expr.name, {})
@@ -3051,7 +3248,12 @@ class _JavaScriptEmitter(Emitter):
             if self._is_map_type(inner) or self._is_set_type(inner):
                 base = inner_str + ".size"
             elif self._is_string_expr(inner) and self._needs_codepoint_ops(inner):
-                base = "[..." + inner_str + "].length"
+                arr = self._rune_arr(inner)
+                if arr is not None:
+                    base = arr + ".length"
+                else:
+                    self._needs_rune_cache = True
+                    base = "_runes(" + inner_str + ").length"
             else:
                 base = inner_str + ".length"
             if self.strict_math:
@@ -3497,8 +3699,8 @@ class _JavaScriptEmitter(Emitter):
                 key_expr = self._expr(first.expr)
             else:
                 return "a"
-            key_a = key_expr.replace(pname, "a", 1)
-            key_b = key_expr.replace(pname, "b", 1)
+            key_a = _replace_ident(key_expr, pname, "a")
+            key_b = _replace_ident(key_expr, pname, "b")
             return key_a + " " + cmp_op + " " + key_b + " ? a : b"
         return "a"
 

--- a/tongues/src/backend/javascript.py
+++ b/tongues/src/backend/javascript.py
@@ -636,6 +636,9 @@ class _JavaScriptEmitter(Emitter):
             for pline in _STRICT_MATH_PREAMBLE.strip().split("\n"):
                 self._line(pline)
             self._line()
+        # The _runes helper must precede top-level lets, which evaluate
+        # during module load; emitted here by insertion once needed
+        rune_cache_pos = len(self.lines)
         declared_structs: set[str] = set()
         for decl in module.decls:
             if isinstance(decl, TStructDecl):
@@ -691,17 +694,20 @@ class _JavaScriptEmitter(Emitter):
             self.indent -= 1
             self._line("}")
         if self._needs_rune_cache:
-            self._line()
-            self._line("// Memoized codepoint arrays for strings of unproven")
-            self._line("// content; V8 caches string hashes so hits are O(1).")
-            self._line("const _runeCache = new Map();")
-            self._line("function _runes(s) {")
-            self.indent += 1
-            self._line("let a = _runeCache.get(s);")
-            self._line("if (a === undefined) { a = [...s]; _runeCache.set(s, a); }")
-            self._line("return a;")
-            self.indent -= 1
-            self._line("}")
+            helper = [
+                "// Memoized codepoint arrays for strings of unproven",
+                "// content; V8 caches string hashes so hits are O(1).",
+                "const _runeCache = new Map();",
+                "function _runes(s) {",
+                "    let a = _runeCache.get(s);",
+                "    if (a === undefined) { a = [...s]; _runeCache.set(s, a); }",
+                "    return a;",
+                "}",
+                "",
+            ]
+            self.lines = (
+                self.lines[0:rune_cache_pos] + helper + self.lines[rune_cache_pos:]
+            )
         if any(isinstance(d, TFnDecl) and d.name == "Main" for d in module.decls):
             self._line()
             self._line(

--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -298,6 +298,19 @@ _OS_BUILTINS = frozenset({"GetEnv"})
 # Built-in error structs whose Taytsh name differs from the Python name
 _ERROR_NAME_MAP = {"AssertError": "AssertionError"}
 
+# Builtin calls that emit as binary operator expressions, and the operator
+# they emit — used for precedence-aware parenthesization in _maybe_paren
+_CALL_OPS = {
+    "Union": "|",
+    "Intersection": "&",
+    "Difference": "-",
+    "Concat": "+",
+    "Repeat": "*",
+    "FloorDiv": "//",
+    "PythonMod": "%",
+    "Contains": "in",
+}
+
 
 def _scan_decl_builtins(decl: TDecl) -> tuple[bool, bool, bool]:
     """Scan a declaration for sys/math/os builtin usage."""
@@ -1078,15 +1091,17 @@ class _PythonEmitter(Emitter):
     def _emit_divmod_assign(self, stmt: TTupleAssignStmt, unused: set[int]) -> None:
         call = stmt.value
         assert isinstance(call, TCall)
-        a = self._expr(call.args[0].value)
-        b = self._expr(call.args[1].value)
+        a_div = self._maybe_paren(call.args[0].value, "/", True)
+        b_div = self._maybe_paren(call.args[1].value, "/", False)
         q_target = self._expr(stmt.targets[0])
         if 1 in unused:
-            self._line(q_target + " = int(" + a + " / " + b + ")")
+            self._line(q_target + " = int(" + a_div + " / " + b_div + ")")
         else:
+            a_sub = self._maybe_paren(call.args[0].value, "-", True)
+            b_mul = self._maybe_paren(call.args[1].value, "*", False)
             r_target = self._expr(stmt.targets[1])
-            self._line(q_target + " = int(" + a + " / " + b + ")")
-            self._line(r_target + " = " + a + " - " + q_target + " * " + b)
+            self._line(q_target + " = int(" + a_div + " / " + b_div + ")")
+            self._line(r_target + " = " + a_sub + " - " + q_target + " * " + b_mul)
 
     def _emit_expr_stmt(self, stmt: TExprStmt) -> None:
         expr = stmt.expr
@@ -1665,9 +1680,9 @@ class _PythonEmitter(Emitter):
                 and expr.operand.annotations.get("provenance") == "not_in_operator"
             ):
                 return (
-                    self._a(expr.operand.args, 1)
+                    self._maybe_paren(expr.operand.args[1].value, "not in", True)
                     + " not in "
-                    + self._a(expr.operand.args, 0)
+                    + self._maybe_paren(expr.operand.args[0].value, "not in", False)
                 )
             py_op = "not "
             if isinstance(expr.operand, (TBinaryOp,)):
@@ -1739,6 +1754,16 @@ class _PythonEmitter(Emitter):
             if expr.op == "!" and parent_op in _CMP_OPS:
                 return "(" + self._expr(expr) + ")"
             if expr.op in ("-", "+") and parent_op == "**" and is_left:
+                return "(" + self._expr(expr) + ")"
+        elif isinstance(expr, TCall) and isinstance(expr.func, TVar):
+            # Builtins emitted as operator expressions need the same
+            # precedence treatment as native binary ops
+            child_op = _CALL_OPS.get(expr.func.name)
+            if (
+                child_op is not None
+                and expr.annotations.get("provenance") != "star_unpack"
+                and _needs_parens(child_op, parent_op, is_left)
+            ):
                 return "(" + self._expr(expr) + ")"
         return self._expr(expr)
 
@@ -2013,11 +2038,17 @@ class _PythonEmitter(Emitter):
         if name == "Delete":
             return self._a(args, 0) + ".pop(" + self._a(args, 1) + ", None)"
         if name == "Union":
-            return self._a(args, 0) + " | " + self._a(args, 1)
+            left = self._maybe_paren(args[0].value, "|", True)
+            right = self._maybe_paren(args[1].value, "|", False)
+            return left + " | " + right
         if name == "Intersection":
-            return self._a(args, 0) + " & " + self._a(args, 1)
+            left = self._maybe_paren(args[0].value, "&", True)
+            right = self._maybe_paren(args[1].value, "&", False)
+            return left + " & " + right
         if name == "Difference":
-            return self._a(args, 0) + " - " + self._a(args, 1)
+            left = self._maybe_paren(args[0].value, "-", True)
+            right = self._maybe_paren(args[1].value, "-", False)
+            return left + " - " + right
         if name == "Merge":
             return "{**" + self._a(args, 0) + ", **" + self._a(args, 1) + "}"
         if name == "Keys":
@@ -2082,22 +2113,12 @@ class _PythonEmitter(Emitter):
                 return "round(" + self._a(args, 0) + ", " + self._a(args, 1) + ")"
             return "round(" + self._a(args, 0) + ")"
         if name == "DivMod":
-            a = self._a(args, 0)
-            b = self._a(args, 1)
-            return (
-                "int("
-                + a
-                + " / "
-                + b
-                + "), "
-                + a
-                + " - int("
-                + a
-                + " / "
-                + b
-                + ") * "
-                + b
-            )
+            a_div = self._maybe_paren(args[0].value, "/", True)
+            b_div = self._maybe_paren(args[1].value, "/", False)
+            a_sub = self._maybe_paren(args[0].value, "-", True)
+            b_mul = self._maybe_paren(args[1].value, "*", False)
+            quot = "int(" + a_div + " / " + b_div + ")"
+            return quot + ", " + a_sub + " - " + quot + " * " + b_mul
         if name == "Sorted":
             if self.strict_math and self._is_float_list(args[0].value):
                 return "strict_sorted_f64(" + self._a(args, 0) + ")"
@@ -2241,7 +2262,9 @@ class _PythonEmitter(Emitter):
             right = self._maybe_paren(args[1].value, "**", is_left=False)
             return left + " ** " + right
         if name == "Contains":
-            return self._a(args, 1) + " in " + self._a(args, 0)
+            left = self._maybe_paren(args[1].value, "in", True)
+            right = self._maybe_paren(args[0].value, "in", False)
+            return left + " in " + right
         if name == "Concat":
             left = self._maybe_paren(args[0].value, "+", True)
             right = self._maybe_paren(args[1].value, "+", False)

--- a/tongues/src/backend/python.py
+++ b/tongues/src/backend/python.py
@@ -295,6 +295,9 @@ _MATH_BUILTINS = frozenset({"IsNaN", "IsInf", "Sqrt", "Floor", "Ceil"})
 
 _OS_BUILTINS = frozenset({"GetEnv"})
 
+# Built-in error structs whose Taytsh name differs from the Python name
+_ERROR_NAME_MAP = {"AssertError": "AssertionError"}
+
 
 def _scan_decl_builtins(decl: TDecl) -> tuple[bool, bool, bool]:
     """Scan a declaration for sys/math/os builtin usage."""
@@ -339,6 +342,9 @@ class _PythonEmitter(Emitter):
     ) -> None:
         self.struct_names = struct_names
         self.struct_fields = struct_fields
+        # Structs declared in the module (excludes implicit built-in errors),
+        # which must not be renamed by _ERROR_NAME_MAP
+        self.declared_structs: set[str] = set()
         self.strict_math = strict_math
         self.strict_tostring = strict_tostring
         self.indent: int = 0
@@ -370,6 +376,8 @@ class _PythonEmitter(Emitter):
         for decl in module.decls:
             if isinstance(decl, TLetStmt):
                 self.module_let_names.add(decl.name)
+            if isinstance(decl, TStructDecl):
+                self.declared_structs.add(decl.name)
         needs_sys, needs_dataclass, needs_field, needs_math, needs_os = _scan_imports(
             module
         )
@@ -1350,7 +1358,10 @@ class _PythonEmitter(Emitter):
         types: list[str] = []
         for t in catch.types:
             if isinstance(t, TIdentType):
-                types.append(t.name)
+                name = t.name
+                if name in _ERROR_NAME_MAP and name not in self.declared_structs:
+                    name = _ERROR_NAME_MAP[name]
+                types.append(name)
             else:
                 types.append(self._type(t))
         if not types:
@@ -1447,6 +1458,8 @@ class _PythonEmitter(Emitter):
 
     def _pattern_type_name(self, typ: TType) -> str:
         if isinstance(typ, TIdentType):
+            if typ.name in _ERROR_NAME_MAP and typ.name not in self.declared_structs:
+                return _ERROR_NAME_MAP[typ.name]
             return typ.name
         return self._type(typ)
 
@@ -1783,6 +1796,13 @@ class _PythonEmitter(Emitter):
         # Builtin call
         if isinstance(func, TVar) and func.name in BUILTIN_NAMES:
             return self._builtin_call(func.name, args)
+        # Built-in error constructor whose Taytsh name differs from Python's
+        if (
+            isinstance(func, TVar)
+            and func.name in _ERROR_NAME_MAP
+            and func.name not in self.declared_structs
+        ):
+            return _ERROR_NAME_MAP[func.name] + "(" + self._join_args(args, ", ") + ")"
         # Struct constructor
         if isinstance(func, TVar) and func.name in self.struct_names:
             return self._struct_call(func.name, args)
@@ -2316,6 +2336,8 @@ class _PythonEmitter(Emitter):
         if isinstance(typ, TTupleType):
             return "tuple[" + self._join_types(typ.elements, ", ") + "]"
         if isinstance(typ, TIdentType):
+            if typ.name in _ERROR_NAME_MAP and typ.name not in self.declared_structs:
+                return _ERROR_NAME_MAP[typ.name]
             return typ.name
         if isinstance(typ, TOptionalType):
             return self._type(typ.inner) + " | None"

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -4929,22 +4929,18 @@ def _lower_tuple_assign(
             for at2 in arg_types:
                 if _is_type_dict(at2, ["float"]):
                     use_float = True
-            if use_float:
-                fa: list[TExpr] = []
-                for la2 in lowered_args:
-                    fa.append(la2)
-                a_expr = fa[0] if fa else lowered_args[0]
-                b_expr = fa[1] if len(fa) > 1 else lowered_args[1]
-                value = TTupleLit(
-                    pos,
-                    {},
-                    [
-                        _make_call(pos, "FloorDiv", [a_expr, b_expr]),
-                        _make_call(pos, "PythonMod", [a_expr, b_expr]),
-                    ],
-                )
-            else:
-                value = _make_call(pos, "DivMod", lowered_args)
+            # Python divmod floors for int and float alike; Taytsh DivMod
+            # truncates, so it cannot represent this
+            a_expr = lowered_args[0]
+            b_expr = lowered_args[1]
+            value = TTupleLit(
+                pos,
+                {},
+                [
+                    _make_call(pos, "FloorDiv", [a_expr, b_expr]),
+                    _make_call(pos, "PythonMod", [a_expr, b_expr]),
+                ],
+            )
             result_kind = "float" if use_float else "int"
             stmts: list[TStmt] = []
             targets: list[TExpr] = []

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -112,6 +112,7 @@ from .types import (
     BOOL_TYPE,
     STR_TYPE,  # noqa: F401 — used by _collection_element_type (added on main)
     VOID_TYPE,
+    slice_indices,
     ANY_TYPE,
     combine_types,
     contains_any,
@@ -3781,7 +3782,7 @@ def _lower_slice(
         ok_st, st_c = _static_slice_part(step_jv)
         if ok_lo and ok_hi and ok_st:
             elems: list[TExpr] = []
-            for i in range(*slice(lo_c, hi_c, st_c).indices(len(obj_type.elements))):
+            for i in slice_indices(lo_c, hi_c, st_c, len(obj_type.elements)):
                 elems.append(TTupleAccess(pos, {}, obj, i))
             return TTupleLit(pos, {}, elems)
         ctx.errors.append(
@@ -7380,9 +7381,7 @@ def _build_module(tree: ASTNode, ctx: _LowerCtx) -> TModule:
         if _is_ast(node, "FunctionDef"):
             fname = get_str(node, "name")
             is_entry = entry_point_func is not None and fname == entry_point_func
-            decls.append(
-                _build_function(node, env, ctx, is_entry, entry_exit_code)
-            )
+            decls.append(_build_function(node, env, ctx, is_entry, entry_exit_code))
         elif _is_ast(node, "Assign") or _is_ast(node, "AnnAssign"):
             const_decl = _build_module_constant(node, constant_names, ctx)
             if const_decl is not None:

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -3897,9 +3897,12 @@ def _lower_step_slice(
         )
         body: list[TStmt] = [append_stmt]
     elif is_bytes:
-        let_type = TListType(pos, TPrimitive(pos, "byte"))
+        # Widen elements to int like bytes for-loops do; every backend's
+        # BytesFrom accepts an int list
+        let_type = TListType(pos, TPrimitive(pos, "int"))
         let_init = TListLit(pos, {}, [])
-        append_call = _make_call(pos, "Append", [result_var, idx_expr])
+        widened = _make_call(pos, "ByteToInt", [idx_expr])
+        append_call = _make_call(pos, "Append", [result_var, widened])
         body = [TExprStmt(pos, {}, append_call)]
     else:
         elt_ttype = _elem_type_from_obj(pos, obj_type)
@@ -6600,7 +6603,14 @@ def _build_function(
     params: list[TParam] = []
     func_env = env.copy()
     func_env.hoisted_stmts = {}
-    func_env.entry_exit_code = is_entry_point and entry_exit_code
+    # Propagate exit codes only from an int-returning main; a None-typed
+    # main under sys.exit() always exits 0
+    func_env.entry_exit_code = (
+        is_entry_point
+        and entry_exit_code
+        and func_info is not None
+        and _is_type_dict(func_info.return_type, ["int"])
+    )
     if func_info is not None:
         for p in func_info.params:
             if _is_non_zero_default(p.default_value):
@@ -7302,29 +7312,38 @@ def _detect_entry_point(body: list[ASTNode]) -> tuple[str, bool] | None:
 
     Returns (function name, propagate_exit_code) — the flag is True for the
     sys.exit(main()) form, where main's return value becomes the exit code.
+
+    Project merge orders dependencies before the root file, and only the
+    root's guard runs when the program executes, so the last guard wins.
     """
+    result: tuple[str, bool] | None = None
     for node in body:
         if _is_ast(node, "If"):
             test = get_node(node, "test")
             if _is_name_main_check(test):
-                for stmt in get_nodes(node, "body"):
-                    if not _is_ast(stmt, "Expr"):
-                        continue
-                    val = get_node(stmt, "value")
-                    if not _is_ast(val, "Call"):
-                        continue
-                    func = get_node(val, "func")
-                    if _is_ast(func, "Name"):
-                        return get_str(func, "id"), False
-                    # sys.exit(main()): exit code comes from main's return
-                    if _is_ast(func, "Attribute") and get_str(func, "attr") == "exit":
-                        args = get_nodes(val, "args")
-                        if args and _is_ast(args[0], "Call"):
-                            inner = get_node(args[0], "func")
-                            if _is_ast(inner, "Name"):
-                                return get_str(inner, "id"), True
-                return "main", True
-    return None
+                result = _entry_point_of_guard(node)
+    return result
+
+
+def _entry_point_of_guard(node: ASTNode) -> tuple[str, bool]:
+    """Extract (function name, propagate_exit_code) from a __main__ guard."""
+    for stmt in get_nodes(node, "body"):
+        if not _is_ast(stmt, "Expr"):
+            continue
+        val = get_node(stmt, "value")
+        if not _is_ast(val, "Call"):
+            continue
+        func = get_node(val, "func")
+        if _is_ast(func, "Name"):
+            return get_str(func, "id"), False
+        # sys.exit(main()): exit code comes from main's return
+        if _is_ast(func, "Attribute") and get_str(func, "attr") == "exit":
+            args = get_nodes(val, "args")
+            if args and _is_ast(args[0], "Call"):
+                inner = get_node(args[0], "func")
+                if _is_ast(inner, "Name"):
+                    return get_str(inner, "id"), True
+    return "main", True
 
 
 def _is_name_main_check(node: ASTNode) -> bool:

--- a/tongues/src/frontend/lowering.py
+++ b/tongues/src/frontend/lowering.py
@@ -962,6 +962,8 @@ class _Env:
         self.hoisted_stmts: dict[str, TLetStmt] = {}
         self.isinstance_subs: dict[str, str] = {}
         self.pre_stmts: list[TStmt] = []
+        # In the sys.exit(main()) entrypoint, return values become exit codes
+        self.entry_exit_code: bool = False
 
     def copy(self) -> _Env:
         env = _Env()
@@ -975,6 +977,7 @@ class _Env:
             env.loop_bindings.add(lb)
         env.return_type = self.return_type
         env.hoisted_stmts = self.hoisted_stmts
+        env.entry_exit_code = self.entry_exit_code
         skeys = list(self.isinstance_subs.keys())
         for skey in skeys:
             env.isinstance_subs[skey] = self.isinstance_subs[skey]
@@ -3772,8 +3775,22 @@ def _lower_slice(
     upper_jv = slice_node.get("upper")
     step_jv = slice_node.get("step")
     has_step = step_jv is not None and not isinstance(step_jv, JNull)
-    is_bytes = _is_type_dict(obj_type, ["bytes"]) or _is_bytes_slice(obj_type)
-    if has_step and not isinstance(obj_type, TupleType) and not is_bytes:
+    if has_step and isinstance(obj_type, TupleType):
+        ok_lo, lo_c = _static_slice_part(lower_jv)
+        ok_hi, hi_c = _static_slice_part(upper_jv)
+        ok_st, st_c = _static_slice_part(step_jv)
+        if ok_lo and ok_hi and ok_st:
+            elems: list[TExpr] = []
+            for i in range(*slice(lo_c, hi_c, st_c).indices(len(obj_type.elements))):
+                elems.append(TTupleAccess(pos, {}, obj, i))
+            return TTupleLit(pos, {}, elems)
+        ctx.errors.append(
+            LoweringError(
+                pos.line, pos.col, "tuple slice with step requires constant bounds"
+            )
+        )
+        return obj
+    if has_step:
         assert step_jv is not None
         return _lower_step_slice(
             pos, obj, obj_type, lower_jv, upper_jv, step_jv, env, ctx
@@ -3792,6 +3809,20 @@ def _lower_slice(
     return TSlice(pos, {}, obj, low, high)
 
 
+def _static_slice_part(jv: JsonValue | None) -> tuple[bool, int | None]:
+    """Extract a constant slice bound: (is_static, value); value None means absent."""
+    if jv is None or isinstance(jv, JNull):
+        return True, None
+    if isinstance(jv, JDict):
+        ci = _get_const_int(jv.entries)
+        if ci is not None:
+            return True, ci
+        neg = _is_neg_const(jv.entries)
+        if neg is not None:
+            return True, -neg
+    return False, None
+
+
 def _lower_step_slice(
     pos: Pos,
     obj: TExpr,
@@ -3804,11 +3835,12 @@ def _lower_step_slice(
 ) -> TExpr:
     """Lower a step-slice xs[a:b:c] into Reversed/Reverse or a hoisted for-loop."""
     is_string = _is_type_dict(obj_type, ["string"])
+    is_bytes = _is_type_dict(obj_type, ["bytes"]) or _is_bytes_slice(obj_type)
     no_lower = lower_jv is None or isinstance(lower_jv, JNull)
     no_upper = upper_jv is None or isinstance(upper_jv, JNull)
-    # xs[::-1] / s[::-1] → Reversed(xs) / Reverse(s)
+    # xs[::-1] / s[::-1] → Reversed(xs) / Reverse(s); no bytes equivalent exists
     step_entries = step_jv.entries if isinstance(step_jv, JDict) else None
-    if no_lower and no_upper and step_entries is not None:
+    if no_lower and no_upper and step_entries is not None and not is_bytes:
         neg = _is_neg_const(step_entries)
         if neg == 1:
             ann: Ann = {"provenance": "reversed_slice"}
@@ -3863,6 +3895,11 @@ def _lower_step_slice(
             pos, {}, result_var, _make_call(pos, "Concat", [result_var, idx_expr])
         )
         body: list[TStmt] = [append_stmt]
+    elif is_bytes:
+        let_type = TListType(pos, TPrimitive(pos, "byte"))
+        let_init = TListLit(pos, {}, [])
+        append_call = _make_call(pos, "Append", [result_var, idx_expr])
+        body = [TExprStmt(pos, {}, append_call)]
     else:
         elt_ttype = _elem_type_from_obj(pos, obj_type)
         let_type = TListType(pos, elt_ttype)
@@ -3871,10 +3908,14 @@ def _lower_step_slice(
         body = [TExprStmt(pos, {}, append_call)]
     let_stmt = TLetStmt(pos, {}, rname, let_type, let_init)
     range_expr = TRange(pos, {}, [start, end, step_expr])
-    for_ann: Ann = {"provenance": "step_slice"}
+    # No step_slice provenance for bytes: the accumulator is a list[byte]
+    # wrapped in BytesFrom, which backend slice reconstruction can't express
+    for_ann: Ann = {} if is_bytes else {"provenance": "step_slice"}
     for_stmt = TForStmt(pos, for_ann, [idx_name], range_expr, body)
     env.pre_stmts.append(let_stmt)
     env.pre_stmts.append(for_stmt)
+    if is_bytes:
+        return _make_call(pos, "BytesFrom", [result_var])
     return result_var
 
 
@@ -4774,6 +4815,12 @@ def _lower_return(node: ASTNode, env: _Env, ctx: _LowerCtx) -> list[TStmt]:
         return [TReturnStmt(pos, {}, None)]
     ret_type = env.return_type
     if isinstance(ret_type, PrimitiveType) and ret_type.kind == "void":
+        if env.entry_exit_code and isinstance(val_jv, JDict):
+            # sys.exit(main()): non-zero return values become exit codes
+            if _get_const_int(val_jv.entries) != 0:
+                code = _lower_expr(val_jv.entries, env, ctx)
+                exit_call = _make_call(pos, "Exit", [code])
+                return [TExprStmt(pos, {}, exit_call), TReturnStmt(pos, {}, None)]
         return [TReturnStmt(pos, {}, None)]
     if isinstance(val_jv, JDict):
         return_val = val_jv.entries
@@ -6540,6 +6587,7 @@ def _build_function(
     env: _Env,
     ctx: _LowerCtx,
     is_entry_point: bool,
+    entry_exit_code: bool = False,
 ) -> TFnDecl:
     """Build a TFnDecl from a FunctionDef node."""
     pos = _node_pos(node)
@@ -6551,6 +6599,7 @@ def _build_function(
     params: list[TParam] = []
     func_env = env.copy()
     func_env.hoisted_stmts = {}
+    func_env.entry_exit_code = is_entry_point and entry_exit_code
     if func_info is not None:
         for p in func_info.params:
             if _is_non_zero_default(p.default_value):
@@ -7247,22 +7296,33 @@ def _build_module_constant(
     return None
 
 
-def _detect_entry_point(body: list[ASTNode]) -> str | None:
-    """Detect if __name__ == '__main__': main() pattern."""
+def _detect_entry_point(body: list[ASTNode]) -> tuple[str, bool] | None:
+    """Detect if __name__ == '__main__': main() pattern.
+
+    Returns (function name, propagate_exit_code) — the flag is True for the
+    sys.exit(main()) form, where main's return value becomes the exit code.
+    """
     for node in body:
         if _is_ast(node, "If"):
             test = get_node(node, "test")
             if _is_name_main_check(test):
-                if_body = get_nodes(node, "body")
-                if if_body:
-                    first = if_body[0]
-                    if _is_ast(first, "Expr"):
-                        val = get_node(first, "value")
-                        if _is_ast(val, "Call"):
-                            func = get_node(val, "func")
-                            if _is_ast(func, "Name"):
-                                return get_str(func, "id")
-                return "main"
+                for stmt in get_nodes(node, "body"):
+                    if not _is_ast(stmt, "Expr"):
+                        continue
+                    val = get_node(stmt, "value")
+                    if not _is_ast(val, "Call"):
+                        continue
+                    func = get_node(val, "func")
+                    if _is_ast(func, "Name"):
+                        return get_str(func, "id"), False
+                    # sys.exit(main()): exit code comes from main's return
+                    if _is_ast(func, "Attribute") and get_str(func, "attr") == "exit":
+                        args = get_nodes(val, "args")
+                        if args and _is_ast(args[0], "Call"):
+                            inner = get_node(args[0], "func")
+                            if _is_ast(inner, "Name"):
+                                return get_str(inner, "id"), True
+                return "main", True
     return None
 
 
@@ -7292,7 +7352,9 @@ def _build_module(tree: ASTNode, ctx: _LowerCtx) -> TModule:
     """Build a TModule from the top-level AST."""
     body = get_nodes(tree, "body")
     decls: list[TModuleItem] = []
-    entry_point_func = _detect_entry_point(body)
+    entry_point = _detect_entry_point(body)
+    entry_point_func = entry_point[0] if entry_point is not None else None
+    entry_exit_code = entry_point[1] if entry_point is not None else False
     # Index class and function AST nodes
     for node in body:
         if _is_ast(node, "ClassDef"):
@@ -7318,7 +7380,9 @@ def _build_module(tree: ASTNode, ctx: _LowerCtx) -> TModule:
         if _is_ast(node, "FunctionDef"):
             fname = get_str(node, "name")
             is_entry = entry_point_func is not None and fname == entry_point_func
-            decls.append(_build_function(node, env, ctx, is_entry))
+            decls.append(
+                _build_function(node, env, ctx, is_entry, entry_exit_code)
+            )
         elif _is_ast(node, "Assign") or _is_ast(node, "AnnAssign"):
             const_decl = _build_module_constant(node, constant_names, ctx)
             if const_decl is not None:

--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -92,6 +92,7 @@ from .types import (
     get_bool,
     get_node,
     get_nodes,
+    slice_indices,
 )
 
 
@@ -1404,9 +1405,9 @@ def _element_type(t: TypeNode) -> TypeNode:
     return ANY_TYPE
 
 
-def _slice_bound_const(node: ASTNode | None) -> tuple[bool, int | None]:
+def _slice_bound_const(node: ASTNode) -> tuple[bool, int | None]:
     """Extract a constant slice bound: (is_static, value); value None means absent."""
-    if not node:
+    if len(node) == 0:
         return True, None
     if _is_type(node, ["Constant"]):
         v = node.get("value")
@@ -1485,10 +1486,8 @@ def _synth_subscript(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
                 ok_st, st = _slice_bound_const(step_node)
                 if ok_lo and ok_hi and ok_st:
                     n = len(obj_type.elements)
-                    idxs = range(*slice(lo, hi, st).indices(n))
-                    return TupleType(
-                        [obj_type.elements[i] for i in idxs], False
-                    )
+                    idxs = slice_indices(lo, hi, st, n)
+                    return TupleType([obj_type.elements[i] for i in idxs], False)
             return obj_type
         if slc and _is_type(slc, ["Constant"]):
             _synth_expr(slc, env, ctx)

--- a/tongues/src/frontend/pycheck.py
+++ b/tongues/src/frontend/pycheck.py
@@ -1404,6 +1404,26 @@ def _element_type(t: TypeNode) -> TypeNode:
     return ANY_TYPE
 
 
+def _slice_bound_const(node: ASTNode | None) -> tuple[bool, int | None]:
+    """Extract a constant slice bound: (is_static, value); value None means absent."""
+    if not node:
+        return True, None
+    if _is_type(node, ["Constant"]):
+        v = node.get("value")
+        if isinstance(v, JInt):
+            return True, v.value
+        return False, None
+    if _is_type(node, ["UnaryOp"]):
+        op = get_node(node, "op")
+        operand = get_node(node, "operand")
+        if op and operand and get_str(op, "_type") == "USub":
+            if _is_type(operand, ["Constant"]):
+                v = operand.get("value")
+                if isinstance(v, JInt):
+                    return True, -v.value
+    return False, None
+
+
 def _synth_subscript(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
     # Check for narrowed subscript type first
     key = _subscript_key(node)
@@ -1458,6 +1478,17 @@ def _synth_subscript(node: ASTNode, env: TypeEnv, ctx: _InferCtx) -> TypeNode:
         if obj_type.variadic and obj_type.elements:
             return obj_type.elements[0]
         if slc and _is_type(slc, ["Slice"]):
+            step_node = get_node(slc, "step")
+            if step_node:
+                ok_lo, lo = _slice_bound_const(get_node(slc, "lower"))
+                ok_hi, hi = _slice_bound_const(get_node(slc, "upper"))
+                ok_st, st = _slice_bound_const(step_node)
+                if ok_lo and ok_hi and ok_st:
+                    n = len(obj_type.elements)
+                    idxs = range(*slice(lo, hi, st).indices(n))
+                    return TupleType(
+                        [obj_type.elements[i] for i in idxs], False
+                    )
             return obj_type
         if slc and _is_type(slc, ["Constant"]):
             _synth_expr(slc, env, ctx)

--- a/tongues/src/frontend/types.py
+++ b/tongues/src/frontend/types.py
@@ -768,3 +768,49 @@ VOID_TYPE: TypeNode = PrimitiveType("void")
 NEVER_TYPE: TypeNode = PrimitiveType("never")
 BYTES_TYPE: TypeNode = SliceType(PrimitiveType("byte"))
 BYTEARRAY_TYPE: TypeNode = ByteArrayType(PrimitiveType("int"))
+
+
+def slice_indices(
+    lo: int | None, hi: int | None, step: int | None, n: int
+) -> list[int]:
+    """Indices selected by a Python slice over a sequence of length n."""
+    st: int = 1 if step is None else step
+    start: int = 0
+    stop: int = 0
+    if st > 0:
+        if lo is None:
+            start = 0
+        elif lo < 0:
+            start = max(0, n + lo)
+        else:
+            start = min(lo, n)
+        if hi is None:
+            stop = n
+        elif hi < 0:
+            stop = max(0, n + hi)
+        else:
+            stop = min(hi, n)
+    else:
+        if lo is None:
+            start = n - 1
+        elif lo < 0:
+            start = max(-1, n + lo)
+        else:
+            start = min(lo, n - 1)
+        if hi is None:
+            stop = -1
+        elif hi < 0:
+            stop = max(-1, n + hi)
+        else:
+            stop = min(hi, n - 1)
+    out: list[int] = []
+    i: int = start
+    if st > 0:
+        while i < stop:
+            out.append(i)
+            i += st
+    else:
+        while i > stop:
+            out.append(i)
+            i += st
+    return out

--- a/tongues/tests/backend/app/known-failures.txt
+++ b/tongues/tests/backend/app/known-failures.txt
@@ -1,9 +1,10 @@
 # Known-failing apptest/target combos: <apptest stem> <target> <issue> [nonstrict]
-# pytest marks these xfail (strict unless 'nonstrict'); the test-transpiled runners skip them.
 # Remove a line when its issue is fixed — a strict xfail that passes fails the suite.
+# pytest marks these xfail (strict unless 'nonstrict'); the test-transpiled runners skip them.
 apptest_base64 java #391 nonstrict
 apptest_base64 javascript #391 nonstrict
 apptest_base64 ruby #391 nonstrict
+apptest_base64 taytsh #391 nonstrict
 apptest_bits perl #391 nonstrict
 apptest_bitset java #391 nonstrict
 apptest_bitset javascript #391 nonstrict
@@ -12,18 +13,22 @@ apptest_bools java #391 nonstrict
 apptest_bools javascript #391 nonstrict
 apptest_bools perl #391 nonstrict
 apptest_bools ruby #391 nonstrict
+apptest_bools taytsh #391 nonstrict
 apptest_bytearray javascript #391 nonstrict
 apptest_bytearray perl #391 nonstrict
 apptest_bytearray python #391 nonstrict
+apptest_bytearray taytsh #391 nonstrict
 apptest_bytes java #391 nonstrict
 apptest_bytes javascript #391 nonstrict
 apptest_bytes perl #391 nonstrict
 apptest_bytes python #391 nonstrict
 apptest_bytes ruby #391 nonstrict
+apptest_bytes taytsh #391 nonstrict
 apptest_chars java #391 nonstrict
 apptest_chars javascript #391 nonstrict
 apptest_chars perl #391 nonstrict
 apptest_chars ruby #391 nonstrict
+apptest_chars taytsh #391 nonstrict
 apptest_crc32 java #391 nonstrict
 apptest_crc32 javascript #391 nonstrict
 apptest_csv javascript #391 nonstrict
@@ -33,6 +38,7 @@ apptest_dicts javascript #391 nonstrict
 apptest_dicts perl #391 nonstrict
 apptest_dicts python #357
 apptest_dicts ruby #391 nonstrict
+apptest_dicts taytsh #391 nonstrict
 apptest_enums java #391 nonstrict
 apptest_enums javascript #391 nonstrict
 apptest_enums perl #391 nonstrict
@@ -42,6 +48,7 @@ apptest_floats java #391 nonstrict
 apptest_floats javascript #391 nonstrict
 apptest_floats perl #391 nonstrict
 apptest_floats ruby #391 nonstrict
+apptest_floats taytsh #391 nonstrict
 apptest_heap javascript #391 nonstrict
 apptest_heap perl #391 nonstrict
 apptest_hierarchy_kind python #388 nonstrict
@@ -52,43 +59,52 @@ apptest_json javascript #391 nonstrict
 apptest_json perl #391 nonstrict
 apptest_json python #387
 apptest_json ruby #391 nonstrict
+apptest_json taytsh #391 nonstrict
 apptest_lists java #391 nonstrict
 apptest_lists javascript #391 nonstrict
 apptest_lists perl #391 nonstrict
 apptest_lists python #386
 apptest_lists ruby #391 nonstrict
+apptest_lists taytsh #391 nonstrict
 apptest_none java #391 nonstrict
 apptest_none javascript #391 nonstrict
 apptest_none perl #391 nonstrict
 apptest_none ruby #391 nonstrict
+apptest_none taytsh #391 nonstrict
 apptest_percent_encode java #391 nonstrict
 apptest_sets java #391 nonstrict
 apptest_sets javascript #391 nonstrict
 apptest_sets perl #391 nonstrict
 apptest_sets python #391 nonstrict
 apptest_sets ruby #391 nonstrict
+apptest_sets taytsh #391 nonstrict
 apptest_sha256 java #391 nonstrict
 apptest_sha256 javascript #391 nonstrict
 apptest_sha256 perl #391 nonstrict
 apptest_sha256 ruby #391 nonstrict
+apptest_sha256 taytsh #391 nonstrict
 apptest_softfloat java #391 nonstrict
 apptest_softfloat javascript #391 nonstrict
 apptest_softfloat perl #389
+apptest_softfloat taytsh #391 nonstrict
 apptest_string_unicode java #391 nonstrict
 apptest_strings java #391 nonstrict
 apptest_strings javascript #391 nonstrict
 apptest_strings perl #391 nonstrict
 apptest_strings ruby #391 nonstrict
+apptest_strings taytsh #391 nonstrict
 apptest_structs javascript #391 nonstrict
 apptest_sub_interface_field javascript #391 nonstrict
 apptest_sub_interface_field perl #391 nonstrict
 apptest_sub_interface_field python #388 nonstrict
 apptest_sub_interface_field ruby #391 nonstrict
+apptest_sub_interface_field taytsh #391 nonstrict
 apptest_tuples java #391 nonstrict
 apptest_tuples javascript #391 nonstrict
 apptest_tuples perl #391 nonstrict
 apptest_tuples python #391 nonstrict
 apptest_tuples ruby #391 nonstrict
+apptest_tuples taytsh #391 nonstrict
 apptest_utf8 java #391 nonstrict
 apptest_utf8 javascript #391 nonstrict
 apptest_utf8 perl #391 nonstrict

--- a/tongues/tests/backend/app/known-failures.txt
+++ b/tongues/tests/backend/app/known-failures.txt
@@ -1,12 +1,95 @@
 # Known-failing apptest/target combos: <apptest stem> <target> <issue> [nonstrict]
 # pytest marks these xfail (strict unless 'nonstrict'); the test-transpiled runners skip them.
 # Remove a line when its issue is fixed — a strict xfail that passes fails the suite.
-apptest_bytes python #384
-apptest_tuples python #384
+apptest_base64 java #391 nonstrict
+apptest_base64 javascript #391 nonstrict
+apptest_base64 ruby #391 nonstrict
+apptest_bits perl #391 nonstrict
+apptest_bitset java #391 nonstrict
+apptest_bitset javascript #391 nonstrict
+apptest_bitset perl #391 nonstrict
+apptest_bools java #391 nonstrict
+apptest_bools javascript #391 nonstrict
+apptest_bools perl #391 nonstrict
+apptest_bools ruby #391 nonstrict
+apptest_bytearray javascript #391 nonstrict
+apptest_bytearray perl #391 nonstrict
+apptest_bytearray python #391 nonstrict
+apptest_bytes java #391 nonstrict
+apptest_bytes javascript #391 nonstrict
+apptest_bytes perl #391 nonstrict
+apptest_bytes python #391 nonstrict
+apptest_bytes ruby #391 nonstrict
+apptest_chars java #391 nonstrict
+apptest_chars javascript #391 nonstrict
+apptest_chars perl #391 nonstrict
+apptest_chars ruby #391 nonstrict
+apptest_crc32 java #391 nonstrict
+apptest_crc32 javascript #391 nonstrict
+apptest_csv javascript #391 nonstrict
+apptest_csv perl #391 nonstrict
+apptest_dicts java #391 nonstrict
+apptest_dicts javascript #391 nonstrict
+apptest_dicts perl #391 nonstrict
 apptest_dicts python #357
+apptest_dicts ruby #391 nonstrict
+apptest_enums java #391 nonstrict
+apptest_enums javascript #391 nonstrict
+apptest_enums perl #391 nonstrict
 apptest_enums python #338
-apptest_json python #387
-apptest_lists python #386
-apptest_sub_interface_field python #388 nonstrict
+apptest_enums ruby #391 nonstrict
+apptest_floats java #391 nonstrict
+apptest_floats javascript #391 nonstrict
+apptest_floats perl #391 nonstrict
+apptest_floats ruby #391 nonstrict
+apptest_heap javascript #391 nonstrict
+apptest_heap perl #391 nonstrict
 apptest_hierarchy_kind python #388 nonstrict
+apptest_ints java #391 nonstrict
+apptest_ints perl #391 nonstrict
+apptest_json java #391 nonstrict
+apptest_json javascript #391 nonstrict
+apptest_json perl #391 nonstrict
+apptest_json python #387
+apptest_json ruby #391 nonstrict
+apptest_lists java #391 nonstrict
+apptest_lists javascript #391 nonstrict
+apptest_lists perl #391 nonstrict
+apptest_lists python #386
+apptest_lists ruby #391 nonstrict
+apptest_none java #391 nonstrict
+apptest_none javascript #391 nonstrict
+apptest_none perl #391 nonstrict
+apptest_none ruby #391 nonstrict
+apptest_percent_encode java #391 nonstrict
+apptest_sets java #391 nonstrict
+apptest_sets javascript #391 nonstrict
+apptest_sets perl #391 nonstrict
+apptest_sets python #391 nonstrict
+apptest_sets ruby #391 nonstrict
+apptest_sha256 java #391 nonstrict
+apptest_sha256 javascript #391 nonstrict
+apptest_sha256 perl #391 nonstrict
+apptest_sha256 ruby #391 nonstrict
+apptest_softfloat java #391 nonstrict
+apptest_softfloat javascript #391 nonstrict
 apptest_softfloat perl #389
+apptest_string_unicode java #391 nonstrict
+apptest_strings java #391 nonstrict
+apptest_strings javascript #391 nonstrict
+apptest_strings perl #391 nonstrict
+apptest_strings ruby #391 nonstrict
+apptest_structs javascript #391 nonstrict
+apptest_sub_interface_field javascript #391 nonstrict
+apptest_sub_interface_field perl #391 nonstrict
+apptest_sub_interface_field python #388 nonstrict
+apptest_sub_interface_field ruby #391 nonstrict
+apptest_tuples java #391 nonstrict
+apptest_tuples javascript #391 nonstrict
+apptest_tuples perl #391 nonstrict
+apptest_tuples python #391 nonstrict
+apptest_tuples ruby #391 nonstrict
+apptest_utf8 java #391 nonstrict
+apptest_utf8 javascript #391 nonstrict
+apptest_utf8 perl #391 nonstrict
+apptest_utf8 ruby #391 nonstrict

--- a/tongues/tests/backend/app/known-failures.txt
+++ b/tongues/tests/backend/app/known-failures.txt
@@ -1,9 +1,6 @@
 # Known-failing apptest/target combos: <apptest stem> <target> <issue> [nonstrict]
 # pytest marks these xfail (strict unless 'nonstrict'); the test-transpiled runners skip them.
 # Remove a line when its issue is fixed — a strict xfail that passes fails the suite.
-apptest_bools python #382
-apptest_sets python #382
-apptest_ints python #383
 apptest_bytes python #384
 apptest_tuples python #384
 apptest_dicts python #357

--- a/tongues/tests/backend/app/known-failures.txt
+++ b/tongues/tests/backend/app/known-failures.txt
@@ -5,6 +5,7 @@ apptest_base64 java #391 nonstrict
 apptest_base64 javascript #391 nonstrict
 apptest_base64 ruby #391 nonstrict
 apptest_base64 taytsh #391 nonstrict
+apptest_bits javascript-vm #396 nonstrict
 apptest_bits perl #391 nonstrict
 apptest_bitset java #391 nonstrict
 apptest_bitset javascript #391 nonstrict

--- a/tongues/tests/backend/codegen/javascript/collections.tests
+++ b/tongues/tests/backend/codegen/javascript/collections.tests
@@ -124,10 +124,10 @@ for (let x of xs) {
 [...xs].sort((a, b) => Math.abs(a) - Math.abs(b));
 
 === min with key lambda
-xs.reduce((a, b) => [...a].length <= [...b].length ? a : b);
+xs.reduce((a, b) => _runes(a).length <= _runes(b).length ? a : b);
 
 === max with key lambda
-xs.reduce((a, b) => [...a].length >= [...b].length ? a : b);
+xs.reduce((a, b) => _runes(a).length >= _runes(b).length ? a : b);
 
 === for over Reversed list
 for (let x of [...xs].reverse()) {

--- a/tongues/tests/backend/codegen/javascript/collections.tests
+++ b/tongues/tests/backend/codegen/javascript/collections.tests
@@ -124,10 +124,10 @@ for (let x of xs) {
 [...xs].sort((a, b) => Math.abs(a) - Math.abs(b));
 
 === min with key lambda
-xs.reduce((a, b) => a.length <= b.length ? a : b);
+xs.reduce((a, b) => [...a].length <= [...b].length ? a : b);
 
 === max with key lambda
-xs.reduce((a, b) => a.length >= b.length ? a : b);
+xs.reduce((a, b) => [...a].length >= [...b].length ? a : b);
 
 === for over Reversed list
 for (let x of [...xs].reverse()) {

--- a/tongues/tests/frontend/lowering/statements.tests
+++ b/tongues/tests/frontend/lowering/statements.tests
@@ -266,7 +266,7 @@ def f() -> int:
     a, b = divmod(10, 3)
     return a
 ---
-a, b = DivMod(10, 3)
+a, b = (FloorDiv(10, 3), PythonMod(10, 3))
 ---
 
 === tuple unpack from list pop into self attributes

--- a/tongues/tests/harness.py
+++ b/tongues/tests/harness.py
@@ -1213,6 +1213,8 @@ def emit_from_python(source: str, lang: str) -> tuple[str | None, str | None]:
         analyze_returns(module, checker)
         analyze_scope(module, checker)
         analyze_liveness(module, checker)
+        if lang in ("ruby", "javascript", "java"):
+            analyze_strings(module, checker)
         return (emitter(module), None)
     except Exception as e:
         return (None, str(e))

--- a/tongues/tests/test-transpiled.js
+++ b/tongues/tests/test-transpiled.js
@@ -514,10 +514,11 @@ function runtimeAvailable(lang) {
 }
 
 // Set of "stem|target" combos expected to fail (see known-failures.txt)
-// In VM mode entries use the pseudo-target "<target>-vm"
+// VM mode skips the union of "<target>" and "<target>-vm" entries
 let _vmMode = false;
-function knownFailureKey(stem, target) {
-    return `${stem}|${target}${_vmMode ? "-vm" : ""}`;
+function isKnownFailure(knownFailures, stem, target) {
+    if (knownFailures.has(`${stem}|${target}`)) return true;
+    return _vmMode && knownFailures.has(`${stem}|${target}-vm`);
 }
 
 function loadKnownFailures(testDir) {
@@ -565,7 +566,7 @@ function runAppTests(testDir) {
         }
         for (const target of available) {
             const testId = `${stem}[${target}]`;
-            if (knownFailures.has(knownFailureKey(stem, target))) {
+            if (isKnownFailure(knownFailures, stem, target)) {
                 results.push(["skip", testId, null]);
                 continue;
             }
@@ -847,7 +848,7 @@ function collectTests() {
                         });
                         for (const target of available) {
                             const testId = `${stem}[${target}]`;
-                            if (knownFailures.has(knownFailureKey(stem, target))) {
+                            if (isKnownFailure(knownFailures, stem, target)) {
                                 collected.push([phaseName, testId, "skip", null]);
                                 continue;
                             }

--- a/tongues/tests/test-transpiled.js
+++ b/tongues/tests/test-transpiled.js
@@ -514,6 +514,12 @@ function runtimeAvailable(lang) {
 }
 
 // Set of "stem|target" combos expected to fail (see known-failures.txt)
+// In VM mode entries use the pseudo-target "<target>-vm"
+let _vmMode = false;
+function knownFailureKey(stem, target) {
+    return `${stem}|${target}${_vmMode ? "-vm" : ""}`;
+}
+
 function loadKnownFailures(testDir) {
     const path = nodePath.join(testDir, "known-failures.txt");
     const known = new Set();
@@ -559,7 +565,7 @@ function runAppTests(testDir) {
         }
         for (const target of available) {
             const testId = `${stem}[${target}]`;
-            if (knownFailures.has(`${stem}|${target}`)) {
+            if (knownFailures.has(knownFailureKey(stem, target))) {
                 results.push(["skip", testId, null]);
                 continue;
             }
@@ -841,7 +847,7 @@ function collectTests() {
                         });
                         for (const target of available) {
                             const testId = `${stem}[${target}]`;
-                            if (knownFailures.has(`${stem}|${target}`)) {
+                            if (knownFailures.has(knownFailureKey(stem, target))) {
                                 collected.push([phaseName, testId, "skip", null]);
                                 continue;
                             }
@@ -1076,6 +1082,7 @@ if (workerpool.isMainThread === false) {
     globalThis.__tonguesMain = globalThis.main;
     loadGlobal(harnessPath);
     if (viaVmPath) {
+        _vmMode = true;
         loadVmModule(viaVmPath);
         runInprocess = runVmInprocess;
     }
@@ -1159,6 +1166,7 @@ if (viaVmPath) {
     }
     console.log(`Loading VM module: ${viaVmPath}`);
     const vmT0 = Date.now();
+    _vmMode = true;
     loadVmModule(viaVmPath);
     console.log(`VM compiled in ${((Date.now() - vmT0) / 1000).toFixed(1)}s`);
     runInprocess = runVmInprocess;

--- a/tongues/tests/test-transpiled.js
+++ b/tongues/tests/test-transpiled.js
@@ -143,7 +143,7 @@ let runInprocess = function runInprocess(argv, stdinData) {
         return origReadFileSync.call(nodeFs, p, enc);
     };
     try {
-        main();
+        __tonguesMain();
     } catch (e) {
         if (e && e[exitSentinel]) {
             exitCode = e.code;
@@ -1071,6 +1071,9 @@ if (workerpool.isMainThread === false) {
     const harnessPath = process.env._TONGUES_HARNESS;
     const viaVmPath = process.env._TONGUES_VM || null;
     loadGlobal(transpiledPath);
+    // The transpiled harness also defines main (its self-test entrypoint)
+    // and overwrites the compiler's on load; keep a reference.
+    globalThis.__tonguesMain = globalThis.main;
     loadGlobal(harnessPath);
     if (viaVmPath) {
         loadVmModule(viaVmPath);
@@ -1138,6 +1141,9 @@ console.log(`Loading transpiled binary: ${transpiledPath}`);
 const t0 = Date.now();
 try {
     loadGlobal(transpiledPath);
+    // The transpiled harness also defines main (its self-test entrypoint)
+    // and overwrites the compiler's on load; keep a reference.
+    globalThis.__tonguesMain = globalThis.main;
 } catch (e) {
     process.stderr.write("Failed to load transpiled binary:\n");
     process.stderr.write(String(e).split("\n").slice(0, 5).join("\n") + "\n");

--- a/tongues/tests/test-transpiled.pl
+++ b/tongues/tests/test-transpiled.pl
@@ -90,6 +90,9 @@ sub get_cpu_count {
 # ---------------------------------------------------------------------------
 
 our $FORK_MODE = 0;
+# Set after loading the transpiled binary; the transpiled harness also
+# defines main (its self-test entrypoint) and overwrites the compiler's.
+our $TONGUES_MAIN;
 BEGIN {
     *CORE::GLOBAL::exit = sub {
         if ($FORK_MODE) {
@@ -166,7 +169,7 @@ sub run_inprocess ($argv, $stdin_data = "") {
         open(STDIN, "<", $in_file) or POSIX::_exit(99);
         @ARGV = @$argv;
         $FORK_MODE = 1;
-        eval { main() };
+        eval { $TONGUES_MAIN->() };
         if ($@) {
             my $err = $@;
             if (ref($err) && ref($err) eq 'HASH' || blessed($err)) {
@@ -1136,6 +1139,7 @@ if ($@) {
     exit 1;
 }
 my $t1 = time();
+$TONGUES_MAIN = \&main;
 printf("Loaded in %.1fs\n", $t1 - $t0);
 
 if (defined $via_vm_path) {

--- a/tongues/tests/test-transpiled.rb
+++ b/tongues/tests/test-transpiled.rb
@@ -112,7 +112,7 @@ def run_inprocess(argv, stdin_data: "")
     $stdout = out
     $stderr = err
     $stdin = StringIO.new(stdin_data)
-    main
+    TONGUES_MAIN.call
   rescue SystemExit => e
     code = e.status
   rescue => e
@@ -981,6 +981,9 @@ rescue SyntaxError => e
   exit 1
 end
 t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+# The transpiled harness also defines main (its self-test entrypoint) and
+# overwrites the compiler's on load; keep a reference to the compiler's.
+TONGUES_MAIN = method(:main)
 puts "Loaded in #{"%.1f" % (t1 - t0)}s"
 
 if via_vm_path

--- a/tongues/tests/test_lang_taytsh.py
+++ b/tongues/tests/test_lang_taytsh.py
@@ -7,7 +7,12 @@ import pytest
 from src.backend.taytsh import emit_taytsh
 from src.taytsh import parse as taytsh_parse
 from src.taytsh.vm import vm_run
-from tests.harness import TESTS_DIR, lower_to_taytsh, _transpile_with_emitter
+from tests.harness import (
+    TESTS_DIR,
+    load_known_failures,
+    lower_to_taytsh,
+    _transpile_with_emitter,
+)
 
 # fmt: off
 TESTS = {
@@ -42,13 +47,16 @@ def pytest_generate_tests(metafunc):
         run = cfg["run"]
         if run == "app" and "app_source" in metafunc.fixturenames:
             apps = sorted(test_dir.glob("apptest_*.py"))
+            known = load_known_failures(test_dir)
             params = []
             for path in apps:
-                marks = (
-                    [pytest.mark.xfail(strict=True)]
-                    if path.stem in _APP_XFAIL_VM
-                    else []
-                )
+                entry = known.get((path.stem, "taytsh"))
+                if path.stem in _APP_XFAIL_VM:
+                    marks = [pytest.mark.xfail(strict=True)]
+                elif entry is not None:
+                    marks = [pytest.mark.xfail(strict=entry[1], reason=entry[0])]
+                else:
+                    marks = []
                 params.append(pytest.param(path, id=path.stem, marks=marks))
             metafunc.parametrize("app_source", params)
         elif run == "ordering" and "ordering_source" in metafunc.fixturenames:


### PR DESCRIPTION
## Summary

Batched fixes per slow-CI-turnaround policy. One commit per concern:

- **#385** — Python backend maps `AssertError` → `AssertionError` (catch, type, match, constructor positions); user-declared structs take precedence
- **#382 + #383** — int `divmod` lowers to `FloorDiv`+`PythonMod` (floor semantics, like the float path); Python backend operator-splicing builtins (`Union`/`Intersection`/`Difference`/`Contains`/`DivMod`/not-in) parenthesize via `_maybe_paren`, and operator-emitting builtin calls are registered in `_CALL_OPS` so they parenthesize as operands: `(a | b) - (a & b)`, not `a | b - a & b`
- **#384** — step slices for bytes (loop accumulator + `BytesFrom`) and tuples (static index computation → tuple literal of element accesses; pycheck types them; non-constant tuple step bounds are a lowering error)
- **exit codes** — `return N` in a `sys.exit(main())` entrypoint lowers to `Exit(N)`. Previously dropped, so caught-and-counted apptest failures still exited 0: **the app suite was vacuous on every target** even after #381. The honest failing census (27 files × 5 targets) is umbrella **#391**; `known-failures.txt` carries it as nonstrict entries
- **#377** — JS `_needs_codepoint_ops` defaults unproven string content to codepoint ops (UTF-16 fast path requires proven ascii/bmp), fixing the mixed index spaces that misparsed astral input. Also fixes the entrypoint guard firing inside worker threads (`module.id === "[stdin]"` instead of `require.main === undefined`)

## Verification

- Local: 4-target app suite green (89 passed / 70 xfailed); codegen suite 1520 passed; `just test-tongues python` green
- **Parable corpus (the red CI this unblocks)**: 4574 JS tests against this branch — failing set is exactly main's minus the #377 unicode test; 19 pre-existing failures exist on unreleased main vs 0.2.5 (separate issue to file)
- Note for the 0.2.6 bump: current main emits `to_sexp` where 0.2.5 emitted `toSexp` — Parable's checked-in runners call `toSexp()` and will need updating (or the naming restored); discovered while validating

Not merging until you give the word.